### PR TITLE
Get test coverage to 100%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 parallel = True
+concurrency = gevent
 source =
     viahtml
     tests/unit

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,11 +4,11 @@ parallel = True
 source =
     viahtml
     tests/unit
+    tests/functional
 
 
 [report]
 show_missing = True
 precision = 2
-# Ouch... 3.3%. Fix this
-fail_under = 3.3
+fail_under = 100.00
 skip_covered = True

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -91,5 +91,5 @@ env = VIA_H_EMBED_URL=http://localhost:3001/hypothesis
 env = VIA_IGNORE_PREFIXES=http://localhost:5000/,http://localhost:3001/,https://localhost:5000/,https://localhost:3001/
 env = VIA_DEBUG=1
 
-mount = /=viahtml/app.py
+mount = /=viahtml/wsgi.py
 uwsgi-socket = 0.0.0.0:3031

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -88,5 +88,5 @@ py-tracebacker = /tmp/via-traceback-
 #env = VIA_H_EMBED_URL=https://cdn.hypothes.is/hypothesis
 #env = VIA_IGNORE_PREFIXES=https://hypothes.is/,https://qa.hypothes.is/,https://cdn.hypothes.is/
 
-mount = /=viahtml/app.py
+mount = /=viahtml/wsgi.py
 uwsgi-socket = /tmp/viahtml-uwsgi.sock

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -1,1 +1,5 @@
 pytest
+webtest
+httpretty
+responses
+h-matchers

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,58 @@
+import os
+
+import pytest
+import webtest
+
+from tests.simple_server import serve_content
+from viahtml.app import Application
+
+
+@pytest.fixture(scope="session")  # pragma: no cover
+def app(with_environ):
+    app = Application.create()
+    app.debug = True
+
+    return webtest.TestApp(app)
+
+
+@pytest.fixture(scope="session")  # pragma: no cover
+def with_environ():
+    # WSGI uses repeated elements to express this, which means we can't use
+    # the standard configparser.ConfigParser to read them. So they are
+    # duplicated here:
+    os.environ.update(
+        {
+            "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
+            "VIA_IGNORE_PREFIXES": "http://localhost:5000/,http://localhost:3001/,https://localhost:5000/,https://localhost:3001/",
+            "VIA_DEBUG": "1",
+        }
+    )
+
+
+@pytest.fixture(autouse=True, scope="session")  # pragma: no cover
+def upstream_website():
+    minimal_valid_html = """
+     <!DOCTYPE html>
+     <html lang="en">
+       <head>
+         <meta charset="utf-8">
+         <title>title</title>
+         <link rel="manifest" href="/manifest.json" type="text/javascript">
+         <link rel="other" href="/other.json" type="text/javascript">
+         <script src="script.js"></script>
+       </head>
+       <body>
+         <!-- upstream content -->
+       </body>
+     </html>
+     """
+
+    with serve_content(minimal_valid_html, port=8080):
+        yield
+
+
+@pytest.fixture(scope="session")  # pragma: no cover
+def proxied_content(app):
+    return app.get(
+        "/proxy/http://localhost:8080/?via.client.openSidebar=yup", expect_errors=True
+    )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -51,7 +51,7 @@ def upstream_website():
         yield
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def proxied_content(app):
     return app.get(
         "/proxy/http://localhost:8080/?via.client.openSidebar=yup", expect_errors=True

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,7 +7,7 @@ from tests.simple_server import serve_content
 from viahtml.app import Application
 
 
-@pytest.fixture(scope="session")  # pragma: no cover
+@pytest.fixture(scope="session")
 def app(with_environ):
     app = Application.create()
     app.debug = True
@@ -15,7 +15,7 @@ def app(with_environ):
     return webtest.TestApp(app)
 
 
-@pytest.fixture(scope="session")  # pragma: no cover
+@pytest.fixture(scope="session")
 def with_environ():
     # WSGI uses repeated elements to express this, which means we can't use
     # the standard configparser.ConfigParser to read them. So they are
@@ -29,7 +29,7 @@ def with_environ():
     )
 
 
-@pytest.fixture(autouse=True, scope="session")  # pragma: no cover
+@pytest.fixture(autouse=True, scope="session")
 def upstream_website():
     minimal_valid_html = """
      <!DOCTYPE html>
@@ -51,7 +51,7 @@ def upstream_website():
         yield
 
 
-@pytest.fixture(scope="session")  # pragma: no cover
+@pytest.fixture(scope="session")
 def proxied_content(app):
     return app.get(
         "/proxy/http://localhost:8080/?via.client.openSidebar=yup", expect_errors=True

--- a/tests/functional/fixups_test.py
+++ b/tests/functional/fixups_test.py
@@ -1,0 +1,17 @@
+class TestFixupsToPywb:
+    # Test random fixups we've made to improve `pywb` behavior
+
+    def test_we_do_not_try_and_rewrite_rel_manifest(self, proxied_content):
+        # The '_id' here means a transparent rewrite, and no insertion of
+        # wombat stuff
+        assert (
+            '<link rel="manifest" href="/proxy/id_/http://localhost:8080/manifest.json"'
+            in proxied_content
+        )
+
+    def test_we_do_rewrite_other_rels(self, proxied_content):
+        print(proxied_content)
+        assert (
+            '<link rel="other" href="/proxy/oe_/http://localhost:8080/other.json"'
+            in proxied_content
+        )

--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.simple_server import serve_content
+
+
+class TestProxy:
+    # Test our the core proxying behavior and our additions to it
+
+    def test_we_can_proxy_a_page(self, proxied_content):
+        assert "upstream content" in proxied_content
+
+    def test_client_embed_is_in_the_page(self, proxied_content):
+        assert (
+            'embed_script.src = "http://localhost:3001/hypothesis"' in proxied_content
+        )
+
+    def test_client_params_are_passed_through(self, proxied_content):
+        assert '"openSidebar": "yup"' in proxied_content
+
+    def test_client_params_are_stripped_from_the_canonical_url(self, proxied_content):
+        assert (
+            '<link rel="canonical" href="http://localhost:8080/"/>' in proxied_content
+        )
+
+    def test_ignore_prefixes_are_added_to_the_wombat_config(self, proxied_content):
+        prefixes = (
+            'wbinfo.ignore_prefixes = ["http://localhost:5000/", "http://loca'  # ...
+        )
+
+        assert prefixes in proxied_content
+
+    def test_we_do_not_have_a_csp_header(self, proxied_content):
+        policy = proxied_content.headers.get("Content-Security-Policy", "*MISSING*")
+
+        assert policy == "*MISSING*"

--- a/tests/functional/pywb_config_test.py
+++ b/tests/functional/pywb_config_test.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest import param
+
+
+class TestPwybConfig:
+    # Check non-via pywb setup
+
+    @pytest.mark.parametrize(
+        "path",
+        (
+            param("/", id="index"),
+            param("/proxy/", id="collection"),
+            param("/proxy/?search=&date-range-from=&date-range-to=", id="search"),
+        ),
+    )
+    def test_irrelevant_pywb_pages_are_disabled(self, app, path):
+        result = app.get(path)
+
+        assert result.content_type == "text/html"
+        assert b"Page not found" in result.body

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -1,0 +1,43 @@
+"""Test utilities for serving content during tests."""
+from contextlib import contextmanager
+from multiprocessing import Process
+from wsgiref.simple_server import make_server
+
+
+def threaded_context(function):
+    """Run a function in a separate process as a context manager.
+
+    This will start the given function in separate process, yield, and then
+    terminate the process.
+    """
+
+    @contextmanager
+    def inner(*args, **kwargs):
+        worker = Process(target=function, args=args, kwargs=kwargs)
+        worker.start()
+
+        yield
+
+        worker.terminate()
+
+    return inner
+
+
+@threaded_context
+def serve_content(content, content_type="text/html", port=8080):
+    """Serve some given content forever with a simple HTTP server.
+
+    :param content: Content to serve to GET requests
+    :param content_type: Mime type to return for content
+    :param port: Port to serve content on
+    """
+    # A relatively simple WSGI application. It's going to print out the
+    # environment dictionary after being updated by setup_testing_defaults
+
+    def simple_app(_environ, start_response):
+        start_response("200 OK", [("Content-type", f"{content_type}; charset=utf-8")])
+
+        return [content.encode("utf-8")]
+
+    with make_server(host="", port=port, app=simple_app) as httpd:
+        httpd.serve_forever()

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -31,8 +31,6 @@ def serve_content(content, content_type="text/html", port=8080):
     :param content_type: Mime type to return for content
     :param port: Port to serve content on
     """
-    # A relatively simple WSGI application. It's going to print out the
-    # environment dictionary after being updated by setup_testing_defaults
 
     def simple_app(_environ, start_response):
         start_response("200 OK", [("Content-type", f"{content_type}; charset=utf-8")])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def with_environ():
+    # WSGI uses repeated elements to express this, which means we can't use
+    # the standard configparser.ConfigParser to read them. So they are
+    # duplicated here:
+    os.environ.update(
+        {
+            "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
+            "VIA_IGNORE_PREFIXES": (
+                # This is one string
+                "http://localhost:5000/,http://localhost:3001/,"
+                "https://localhost:5000/,https://localhost:3001/"
+            ),
+            "VIA_DEBUG": "1",
+        }
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,15 +1,12 @@
-import os
+from unittest.mock import patch
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def with_environ():
-    # WSGI uses repeated elements to express this, which means we can't use
-    # the standard configparser.ConfigParser to read them. So they are
-    # duplicated here:
-    os.environ.update(
-        {
+def os():
+    with patch("viahtml.app.os", autospec=True) as os:
+        os.environ = {
             "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
             "VIA_IGNORE_PREFIXES": (
                 # This is one string
@@ -18,4 +15,4 @@ def with_environ():
             ),
             "VIA_DEBUG": "1",
         }
-    )
+        yield os

--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -1,0 +1,90 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from h_matchers import Any
+from pytest import param
+from pywb.apps.frontendapp import FrontEndApp
+from pywb.apps.rewriterapp import RewriterApp
+
+from viahtml.app import Application
+
+
+# For reasons I find absolutely mysterious, everytime we create our app
+# coverage can no longer be detected on lines following it. We absolutely get
+# there but for some reason it doesn't show in the report?
+class TestApplicationCreate:  # pragma: no cover
+    def test_it_returns_an_app(self):
+        app = Application.create()
+
+        assert isinstance(app, FrontEndApp)
+
+    @patch("viahtml.app.apply_pre_app_hooks", autospec=True)
+    def test_it_applies_pre_app_hooks(self, apply_pre_app_hooks, Hooks):
+        Application.create()
+
+        apply_pre_app_hooks.assert_called_once_with(Hooks.return_value)
+
+    @patch("viahtml.app.apply_post_app_hooks", autospec=True)
+    def test_it_applies_post_app_hooks(self, apply_post_app_hooks, Hooks):
+        Application.create()
+
+        apply_post_app_hooks.assert_called_once_with(
+            Any.instance_of(RewriterApp), Hooks.return_value
+        )
+
+    @pytest.mark.parametrize(
+        "variable,value,expected",
+        (
+            ("VIA_DEBUG", "value", {"debug": "value"}),
+            (
+                "VIA_IGNORE_PREFIXES",
+                "  value_1, value_2 ",
+                {"ignore_prefixes": ["value_1", "value_2"]},
+            ),
+            ("VIA_H_EMBED_URL", "value", {"h_embed_url": "value"}),
+        ),
+    )
+    def test_it_reads_options_from_environment_variables(
+        self, variable, value, expected, Hooks
+    ):
+        os.environ[variable] = value
+
+        Application.create()
+
+        Hooks.assert_called_once_with(Any.dict.containing(expected))
+
+    def test_it_sets_the_config_file_for_pywb(self):
+        Application.create()
+
+        assert os.environ["PYWB_CONFIG_FILE"] == "pywb_config.yaml"
+
+    @patch("os.path.exists", autospec=True)
+    def test_it_detects_missing_config_file(self, exists):
+        exists.return_value = False
+
+        with pytest.raises(EnvironmentError):
+            Application.create()
+
+    @pytest.mark.parametrize(
+        "debug_enabled",
+        (
+            param("1", id="debug"),
+            param("", id="no debug"),
+        ),
+    )
+    def test_it_configures_logging(self, debug_enabled):
+        os.environ["VIA_DEBUG"] = debug_enabled
+
+        with patch("viahtml.app.logging", autospec=True) as logging:
+            Application.create()
+
+            logging.basicConfig.assert_called_once_with(
+                format=Any.string(),
+                level=logging.DEBUG if debug_enabled else logging.INFO,
+            )
+
+    @pytest.fixture
+    def Hooks(self):
+        with patch("viahtml.app.Hooks", autospec=True) as Hooks:
+            yield Hooks

--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -13,7 +13,7 @@ from viahtml.app import Application
 # For reasons I find absolutely mysterious, everytime we create our app
 # coverage can no longer be detected on lines following it. We absolutely get
 # there but for some reason it doesn't show in the report?
-class TestApplicationCreate:  # pragma: no cover
+class TestApplicationCreate:
     def test_it_returns_an_app(self):
         app = Application.create()
 

--- a/tests/unit/viahtml/hooks_test.py
+++ b/tests/unit/viahtml/hooks_test.py
@@ -1,0 +1,50 @@
+from unittest.mock import patch, sentinel
+
+import pytest
+from h_matchers import Any
+
+from viahtml.hooks import Hooks
+
+
+class TestHooks:
+    def test_template_vars(self, hooks):
+        assert hooks.template_vars == {
+            "client_params": Any.function(),
+            "ignore_prefixes": hooks.ignore_prefixes,
+        }
+
+    def test_client_params_in_template_vars(self, hooks):
+        with patch.object(hooks, "get_config") as get_config:
+            get_config.return_value = ["via", "client"]
+            client_params = hooks.template_vars["client_params"]
+
+            params = client_params(sentinel.http_env)
+
+            assert params == "client"
+            get_config.assert_called_once_with(sentinel.http_env)
+
+    def test_ignore_prefixes(self, hooks):
+        assert hooks.ignore_prefixes == sentinel.prefixes
+
+    def test_get_config(self, Configuration, hooks):
+        config = hooks.get_config(sentinel.http_env)
+
+        Configuration.extract_from_wsgi_environment.assert_called_once_with(
+            sentinel.http_env
+        )
+        assert config == Configuration.extract_from_wsgi_environment.return_value
+
+    def test_get_upstream_url(self, Configuration):
+        config = Hooks({}).get_upstream_url(sentinel.doc_url)
+
+        Configuration.strip_from_url.assert_called_once_with(sentinel.doc_url)
+        assert config == Configuration.strip_from_url.return_value
+
+    @pytest.fixture
+    def hooks(self):
+        return Hooks({"ignore_prefixes": sentinel.prefixes})
+
+    @pytest.fixture
+    def Configuration(self):
+        with patch("viahtml.hooks.Configuration", autospec=True) as Configuration:
+            yield Configuration

--- a/tests/unit/viahtml/wsgi_test.py
+++ b/tests/unit/viahtml/wsgi_test.py
@@ -1,0 +1,9 @@
+from pywb.apps.frontendapp import FrontEndApp
+
+
+def test_it_exports_application():
+    # For fixtures to kick in we need to import this here, as all the work
+    # happens instantly
+    from viahtml.wsgi import application  # pylint: disable=import-outside-toplevel
+
+    assert isinstance(application, FrontEndApp)  # pragma: no cover

--- a/tests/unit/viahtml/wsgi_test.py
+++ b/tests/unit/viahtml/wsgi_test.py
@@ -6,4 +6,4 @@ def test_it_exports_application():
     # happens instantly
     from viahtml.wsgi import application  # pylint: disable=import-outside-toplevel
 
-    assert isinstance(application, FrontEndApp)  # pragma: no cover
+    assert isinstance(application, FrontEndApp)

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     format: isort --quiet --atomic viahtml tests bin
     checkformatting: black --check viahtml tests bin
     checkformatting: isort --quiet --check-only viahtml tests bin
-    tests: coverage run -m pytest {posargs:tests/unit/}
+    tests: coverage run -m pytest {posargs:tests/}
     tests: -coverage combine
     tests: coverage report
     pip-compile: pip-compile {posargs}

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -7,8 +7,8 @@ from pkg_resources import resource_filename
 from pywb.apps.frontendapp import FrontEndApp
 
 # I've no idea how we aren't hitting coverage on these lines
-from viahtml.hooks import Hooks  # pragma: no cover
-from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks  # pragma: no cover
+from viahtml.hooks import Hooks
+from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks
 
 
 class Application:

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -1,18 +1,14 @@
-"""The application providing a WSGI entry-point."""
-
+"""The WSGI app."""
 
 import logging
 import os
 
-from gevent.monkey import patch_all
-
-patch_all()  # This needs to happen before we load other classes
-
-# pylint: disable=wrong-import-position
+from pkg_resources import resource_filename
 from pywb.apps.frontendapp import FrontEndApp
 
-from viahtml.hooks import Hooks
-from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks
+# I've no idea how we aren't hitting coverage on these lines
+from viahtml.hooks import Hooks  # pragma: no cover
+from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks  # pragma: no cover
 
 
 class Application:
@@ -23,7 +19,7 @@ class Application:
         """Create a WSGI application for proxying HTML."""
 
         # Move into the correct directory as template paths are relative
-        os.chdir("viahtml")
+        os.chdir(resource_filename("viahtml", "."))
         config_file = os.environ["PYWB_CONFIG_FILE"] = "pywb_config.yaml"
 
         if not os.path.exists(config_file):
@@ -67,8 +63,3 @@ class Application:
     @classmethod
     def _split_multiline(cls, value):
         return [part for part in [p.strip() for p in value.split(",")] if part]
-
-
-# Our job here is to leave this `application` attribute laying around as it's
-# what uWSGI expects to find.
-application = Application.create()  # pylint: disable=invalid-name

--- a/viahtml/templates/error.html
+++ b/viahtml/templates/error.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Pywb Error{% endblock %}
+{% block title %}Via Error{% endblock %}
 {% block body %}
 <div class="container text-danger">
     <div class="row justify-content-center">

--- a/viahtml/templates/index.html
+++ b/viahtml/templates/index.html
@@ -1,1 +1,1 @@
-Coming soon
+Page not found

--- a/viahtml/templates/query.html
+++ b/viahtml/templates/query.html
@@ -1,1 +1,1 @@
-Coming soon
+Page not found

--- a/viahtml/templates/search.html
+++ b/viahtml/templates/search.html
@@ -1,1 +1,1 @@
-Coming soon
+Page not found

--- a/viahtml/wsgi.py
+++ b/viahtml/wsgi.py
@@ -1,0 +1,11 @@
+"""The application providing a WSGI entry-point."""
+
+from gevent.monkey import patch_all
+
+patch_all()  # This needs to happen before we load other classes
+
+# Our job here is to leave this `application` attribute laying around as
+# it's what uWSGI expects to find.
+from viahtml.app import Application  # pylint: disable=wrong-import-position
+
+application = Application.create()  # pylint: disable=invalid-name


### PR DESCRIPTION
There were a number of problems getting this done:

 * A lot of how this works is bound up in patching `pywb`
 * I can't really think of a non functional way to test most of this
 * `pywb` somehow breaks coverage reports... I don't know how but it's weird
 * The app you start starts another in a separate process, so you can't patch things

So the approach has been to:

 * Unit test what we can
 * Functionally test the rest
 * Expand the coverage report to span both sets of tests
 * Liberally apply `pragma: no cover` to things which clearly should be covered by running the tests
 * Run a small, but real web server in a separate process to have something reliable to call

As an interesting aside, because the functional tests make more extensive use of session scoped fixtures, they are actually much faster than the unit tests. This is because they largely amount to a single call which we now make multiple separate assertions about. 

I wonder if there's scope to make more use of that technique when we have a single object we want to make more assertions about?