### PR TITLE
Make the application be the WSGI app instead of create one

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -9,7 +9,7 @@ from viahtml.app import Application
 
 @pytest.fixture(scope="session")
 def app(with_environ):
-    app = Application.create()
+    app = Application()
     app.debug = True
 
     return webtest.TestApp(app)

--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -5,25 +5,19 @@ from unittest.mock import patch
 import pytest
 from h_matchers import Any
 from pytest import param
-from pywb.apps.frontendapp import FrontEndApp
 from pywb.apps.rewriterapp import RewriterApp
 
 
 class TestApplicationCreate:
-    def test_it_returns_an_app(self):
-        app = Application.create()
-
-        assert isinstance(app, FrontEndApp)
-
     @patch("viahtml.app.apply_pre_app_hooks", autospec=True)
     def test_it_applies_pre_app_hooks(self, apply_pre_app_hooks, Hooks):
-        Application.create()
+        Application()
 
         apply_pre_app_hooks.assert_called_once_with(Hooks.return_value)
 
     @patch("viahtml.app.apply_post_app_hooks", autospec=True)
     def test_it_applies_post_app_hooks(self, apply_post_app_hooks, Hooks):
-        Application.create()
+        Application()
 
         apply_post_app_hooks.assert_called_once_with(
             Any.instance_of(RewriterApp), Hooks.return_value
@@ -47,12 +41,12 @@ class TestApplicationCreate:
     ):
         os.environ[variable] = value
 
-        Application.create()
+        Application()
 
         Hooks.assert_called_once_with(Any.dict.containing(expected))
 
     def test_it_sets_the_config_file_for_pywb(self, os):
-        Application.create()
+        Application()
 
         assert os.environ["PYWB_CONFIG_FILE"] == "pywb_config.yaml"
 
@@ -60,7 +54,7 @@ class TestApplicationCreate:
         os.path.exists.return_value = False
 
         with pytest.raises(EnvironmentError):
-            Application.create()
+            Application()
 
     @pytest.mark.parametrize(
         "debug_enabled",
@@ -72,7 +66,7 @@ class TestApplicationCreate:
     def test_it_configures_logging(self, debug_enabled, os, logging):
         os.environ["VIA_DEBUG"] = debug_enabled
 
-        Application.create()
+        Application()
 
         logging.basicConfig.assert_called_once_with(
             format=Any.string(),

--- a/tests/unit/viahtml/wsgi_test.py
+++ b/tests/unit/viahtml/wsgi_test.py
@@ -1,4 +1,4 @@
-from pywb.apps.frontendapp import FrontEndApp
+from viahtml.app import Application
 
 
 def test_it_exports_application():
@@ -6,4 +6,4 @@ def test_it_exports_application():
     # happens instantly
     from viahtml.wsgi import application  # pylint: disable=import-outside-toplevel
 
-    assert isinstance(application, FrontEndApp)
+    assert isinstance(application, Application)

--- a/viahtml/wsgi.py
+++ b/viahtml/wsgi.py
@@ -1,11 +1,7 @@
 """The application providing a WSGI entry-point."""
 
-from gevent.monkey import patch_all
-
-patch_all()  # This needs to happen before we load other classes
-
 # Our job here is to leave this `application` attribute laying around as
 # it's what uWSGI expects to find.
-from viahtml.app import Application  # pylint: disable=wrong-import-position
+from viahtml.app import Application
 
-application = Application.create()  # pylint: disable=invalid-name
+application = Application()  # pylint: disable=invalid-name


### PR DESCRIPTION
For whatever mysterious reason, this caused the gevent monkey patching
to kick in at a different time when importing the FrontEndApp, which
makes me think we don't need it...

### Why?

This is to set us up for the header blocking PR: https://github.com/hypothesis/viahtml/pull/4. We're going to need to modify the headers on the way in and out. This means we need to _be_ the app, rather than just have one.