### PR TITLE
Proxy the upstream cache control header with translation

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -47,7 +47,11 @@ def upstream_website():
      </html>
      """
 
-    with serve_content(minimal_valid_html, port=8080):
+    with serve_content(
+        minimal_valid_html,
+        port=8080,
+        extra_headers={"Cache-Control": "public, max-age=60"},
+    ):
         yield
 
 

--- a/tests/functional/headers_test.py
+++ b/tests/functional/headers_test.py
@@ -15,3 +15,8 @@ class TestHeaders:
         self, proxied_content, header_name
     ):
         assert header_name not in proxied_content.headers
+
+    def test_cache_control_translation(self, proxied_content):
+        # This is set in the content served, we're looking for public to become
+        # private as the time is lower than the Cloudflare minimum
+        assert proxied_content.headers["Cache-Control"] == "max-age=60, private"

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -24,16 +24,20 @@ def threaded_context(function):
 
 
 @threaded_context
-def serve_content(content, content_type="text/html", port=8080):
+def serve_content(content, content_type="text/html", port=8080, extra_headers=None):
     """Serve some given content forever with a simple HTTP server.
 
     :param content: Content to serve to GET requests
     :param content_type: Mime type to return for content
     :param port: Port to serve content on
+    :param extra_headers: A dict of headers to add to the response
     """
 
     def simple_app(_environ, start_response):
-        start_response("200 OK", [("Content-type", f"{content_type}; charset=utf-8")])
+        headers = [("Content-type", f"{content_type}; charset=utf-8")]
+        headers.extend(extra_headers.items())
+
+        start_response("200 OK", headers)
 
         return [content.encode("utf-8")]
 

--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=wrong-import-order
 from viahtml.app import Application  # isort:skip
 
+# pylint: disable=wrong-import-order
 from unittest.mock import create_autospec, patch, sentinel
 
 import pytest

--- a/tests/unit/viahtml/hooks/_headers_test.py
+++ b/tests/unit/viahtml/hooks/_headers_test.py
@@ -21,23 +21,53 @@ class TestHeaders:
         assert "HTTP_OTHER_HEADER" in http_env
 
     @pytest.mark.parametrize(
-        "case",
-        (
-            param(lambda v: v, id="mixed case"),
-            param(lambda v: v.lower(), id="lower case"),
-            param(lambda v: v.upper(), id="upper case"),
-        ),
+        "header_name", Headers.BLOCKED_OUTBOUND - {"X-Archive-Orig-Cache-Control"}
     )
-    @pytest.mark.parametrize("header_name", Headers.BLOCKED_OUTBOUND)
-    def test_modify_outbound_removes_blocked_items(self, headers, header_name, case):
+    def test_modify_outbound_removes_blocked_items(
+        self, headers, header_name, string_case
+    ):
         items = (
             ("Other-Header", "ok"),
-            (case(header_name), "blocked"),
+            (string_case(header_name), "blocked"),
         )
 
         items = headers.modify_outbound(items)
 
         assert items == [("Other-Header", "ok")]
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        (
+            # Things we don't mess with
+            ("invalid_header", "invalid_header"),
+            ("no-cache, must-revalidate", "no-cache, must-revalidate"),
+            ("max-age=604800", "max-age=604800"),
+            ("private, max-age=0", "private, max-age=0"),
+            ("private, max-age=604800", "private, max-age=604800"),
+            # When the cache is public, and below cloudflare caching numbers, we
+            # mark it as private only. The order changes a bit here too
+            ("public, max-age=0", "max-age=0, private"),
+            ("public, max-age=100", "max-age=100, private"),
+            # Back to over the Cloudflare minimum
+            ("public, max-age=604800", "public, max-age=604800"),
+        ),
+    )
+    def test_cache_control_translation(self, headers, value, expected, string_case):
+        items = headers.modify_outbound(
+            ((string_case("X-Archive-Orig-Cache-Control"), value),)
+        )
+
+        assert items == [("Cache-Control", expected)]
+
+    @pytest.fixture(
+        params=(
+            param(lambda v: v, id="mixed case"),
+            param(lambda v: v.lower(), id="lower case"),
+            param(lambda v: v.upper(), id="upper case"),
+        )
+    )
+    def string_case(self, request):
+        return request.param
 
     @pytest.fixture
     def headers(self):


### PR DESCRIPTION
If the cache is marked public and has a max-age below the minimum of
Cloudflare we flip it to private.