### PR TITLE
Get Viahtml ready for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 supervisord.log
 supervisord.pid
 static/pywb
+build.tar

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build: python
 .PHONY: docker
 docker: build
 	@git archive --format=tar HEAD > build.tar
-	@tar --update -f build.tar via/static
+	@tar --update -f build.tar static
 	@gzip -c build.tar | docker build -t hypothesis/viahtml:$(DOCKER_TAG) -
 	@rm build.tar
 


### PR DESCRIPTION
A place holder for changes required to get the app to deploy. This currently only actually removes a dodgy reference to old via. We don't keep the static directory in the same place.