### PR TITLE
Set the target directory for static content correctly

### DIFF
--- a/bin/build_static.py
+++ b/bin/build_static.py
@@ -28,7 +28,11 @@ def _create_static(source, target):
 
 
 if __name__ == "__main__":
+    # pylint: disable=invalid-name
+    bin_dir = os.path.abspath(os.path.dirname(__file__))
+    root_dir = os.path.abspath(os.path.join(bin_dir, "../static/pywb"))
+
     _create_static(
         source=resource_filename("pywb", "static"),
-        target=os.path.abspath("../static/pywb"),
+        target=root_dir,
     )


### PR DESCRIPTION
Previously this was doing something very weird and getting the parent
directory instead of the project directory.