### PR TITLE
Add external_link_mode option to open links in a new tab

### DIFF
--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -33,3 +33,19 @@ class TestProxy:
         policy = proxied_content.headers.get("Content-Security-Policy", "*MISSING*")
 
         assert policy == "*MISSING*"
+
+    @pytest.mark.parametrize(
+        "link_mode,expected",
+        (
+            ("new-tab", "new-tab"),
+            (None, "same-tab"),
+        ),
+    )
+    def test_we_set_external_link_mode(self, app, link_mode, expected):
+        url = "/proxy/http://localhost:8080/"
+        if link_mode is not None:
+            url += f"?via.external_link_mode={link_mode}"
+
+        proxied_content = app.get(url)
+
+        assert f'setupExternalLinkHandler("{expected}");' in proxied_content

--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -10,6 +10,7 @@ class TestHooks:
     def test_template_vars(self, hooks):
         assert hooks.template_vars == {
             "client_params": Any.function(),
+            "external_link_mode": Any.function(),
             "ignore_prefixes": hooks.ignore_prefixes,
         }
 
@@ -22,6 +23,24 @@ class TestHooks:
 
             assert params == "client"
             get_config.assert_called_once_with(sentinel.http_env)
+
+    @pytest.mark.parametrize(
+        "link_mode,expected",
+        (
+            ("new-tab", "new-tab"),
+            ("same-tab", "same-tab"),
+            (None, "same-tab"),
+            ("random", "random"),
+        ),
+    )
+    def test_external_link_mode_in_template_vars(self, hooks, link_mode, expected):
+        http_env = {}
+        if link_mode is not None:
+            http_env["QUERY_STRING"] = f"via.external_link_mode={link_mode}"
+
+        external_link_mode = hooks.template_vars["external_link_mode"]
+
+        assert external_link_mode(http_env) == expected
 
     def test_ignore_prefixes(self, hooks):
         assert hooks.ignore_prefixes == sentinel.prefixes

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -16,7 +16,16 @@ class Hooks:
     def template_vars(self):
         """Get variables to make available in the global Jinja2 environment."""
 
-        template_vars = {"client_params": lambda http_env: self.get_config(http_env)[1]}
+        def external_link_mode(http_env):
+            via_config, _ = self.get_config(http_env)
+            return via_config.get("external_link_mode", "same-tab").lower()
+
+        template_vars = {
+            # It would be much nicer to calculate this once somehow
+            "client_params": lambda http_env: self.get_config(http_env)[1],
+            "external_link_mode": external_link_mode,
+        }
+
         template_vars.update(self.config)
 
         # This is already in the config, but run through the property just in

--- a/viahtml/templates/banner.html
+++ b/viahtml/templates/banner.html
@@ -111,5 +111,7 @@
         var embed_script = document.createElement("script");
         embed_script.src = "{{ h_embed_url }}";
         document.head.appendChild(embed_script);
+
+        setupExternalLinkHandler({{external_link_mode(env) | tojson}});
     })();
 </script>


### PR DESCRIPTION
This allows you to set an option and have links open in a new tab. For: https://github.com/hypothesis/via3/issues/259

## Testing

Negative case:

 * `make dev`
 * Visit: http://localhost:9085/proxy/http://example.com/
 * Click on the link
 * The link should open in this tab

Positive case:

 * `make dev`
 * Visit: http://localhost:9085/proxy/http://example.com/?via.external_link_mode=new-tab
 * Click on the link
 * It should open in a new tab
 * Click on a link in that tab
 * Links should stay within the same page