### PR TITLE
Build the static items directly in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY ./conf/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./conf/nginx/viahtml /etc/nginx/viahtml
 COPY . .
 
+# Minic the `make build` behavior in tox to build the static assets
+RUN python bin/build_static.py
+RUN python -m whitenoise.compress --no-brotli static
+
 USER hypothesis
 
 CMD /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,8 @@ build: python
 	@tox -qe build
 
 .PHONY: docker
-docker: build
-	@git archive --format=tar HEAD > build.tar
-	@tar --update -f build.tar static
-	@gzip -c build.tar | docker build -t hypothesis/viahtml:$(DOCKER_TAG) -
-	@rm build.tar
+docker:
+	@git archive --format=tar HEAD | docker build -t hypothesis/viahtml:$(DOCKER_TAG) -
 
 .PHONY: clean
 clean:

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 h_vialib
 uwsgi
 pywb
+whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,5 @@ warcio==1.7.4             # via pywb
 webassets==0.12.1         # via pywb
 webencodings==0.5.1       # via pywb
 werkzeug==1.0.1           # via pywb
+whitenoise==5.2.0         # via -r requirements.in
 wsgiprox==1.5.2           # via pywb


### PR DESCRIPTION
This unfortunately leaves whitenoise installed, but hey ho.

It turns out we don't use `make docker` when making the docker image for deployment here: https://github.com/hypothesis/pipeline-library/blob/master/vars/buildApp.groovy

This means the changes to fix it that were made locally don't apply. We have to build inside the docker image instead.