### PR TITLE
Jenkinsfile update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,15 +41,15 @@ node {
 
 onlyOnMaster {
     milestone()
-    stage("qa deploy") {
-        deployApp(image: img, app: "viahtml", env: "qa")
+    stage("qa3 deploy") {
+        deployApp(image: img, app: "viahtml", env: "qa3")
     }
 
     milestone()
-    stage("prod deploy") {
+    stage("prod3 deploy") {
         input(message: "Deploy to prod?")
         milestone()
-        deployApp(image: img, app: "viahtml", env: "prod")
+        deployApp(image: img, app: "viahtml", env: "prod3")
     }
 }
 


### PR DESCRIPTION
This branch delivers an update to the ViaHTML Jenkinsfile. I have documented the problems we have been experiencing here: https://github.com/hypothesis/playbook/issues/433

In essence, we have a single repository that has the potential to be the source for many jobs in Jenkins. The Jenkins file as it is written passes a string `viahtml` which does not relate to the name of the Jenkins job we have defined, that is `viahtml3`. I suspect this is the reason we are running into trouble.

The update introduces a new variable, `app` which has been set to the name of the job in Jenkins `"$env.JOB_NAME"`. The contents of `app` are then passed to `deployApp` as part of the `onlyOnMaster` and `milestone` stages

## Update! New plan

In ViaHTML fix the Jenkins file to match

```
stage("qa deploy") {
    deployApp(image: img, app: "viahtml", env: "qa3")
}
```
->
```
stage("qa3 deploy") {
    deployApp(image: img, app: "viahtml", env: "qa3")
}
```


Same for the prod one too.
 