### PR TITLE
Add a landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Environment variables:
 | `VIA_DEBUG`           | Enable debugging logging in dev        | `1` |
 | `VIA_H_EMBED_URL`     | Client URL                             | `https://cdn.hypothes.is/hypothesis` |
 | `VIA_IGNORE_PREFIXES` | Prefixes not to proxy                  | `https://hypothes.is/,https://qa.hypothes.is/` |
+| `VIA_ROUTING_HOST`    | The host to perform content based routing | `https://via3.hypothes.is` |
 
 For details of changing the blocklist see:
 

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -91,7 +91,7 @@ env = VIA_H_EMBED_URL=http://localhost:3001/hypothesis
 env = VIA_IGNORE_PREFIXES=http://localhost:5000/,http://localhost:3001/,https://localhost:5000/,https://localhost:3001/
 env = VIA_DEBUG=1
 env = VIA_BLOCKLIST_PATH=../conf/blocklist-dev.txt
-
+env = VIA_ROUTING_HOST=http://localhost:9083
 
 py-autoreload = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,5 @@ def environment_variables():
         ),
         "VIA_DEBUG": "1",
         "VIA_BLOCKLIST_PATH": "../conf/blocklist-dev.txt",
+        "VIA_ROUTING_HOST": "http://example.com/via3",
     }

--- a/tests/functional/pywb_config_test.py
+++ b/tests/functional/pywb_config_test.py
@@ -8,7 +8,6 @@ class TestPwybConfig:
     @pytest.mark.parametrize(
         "path",
         (
-            param("/", id="index"),
             param("/proxy/", id="collection"),
             param("/proxy/?search=&date-range-from=&date-range-to=", id="search"),
         ),

--- a/tests/functional/viahtml/views/routing_test.py
+++ b/tests/functional/viahtml/views/routing_test.py
@@ -1,0 +1,5 @@
+def test_routing_view_is_connected_correctly(app):
+    response = app.get("/")
+
+    assert response.status_code == 307
+    assert response.headers["Location"]

--- a/tests/unit/viahtml/views/routing_test.py
+++ b/tests/unit/viahtml/views/routing_test.py
@@ -1,0 +1,33 @@
+from h_matchers import Any
+
+from viahtml.views.routing import RoutingView
+
+
+class TestRoutingView:
+    def test_it_skips_non_routing_urls(self, start_response):
+        view = RoutingView(routing_host="*any*")
+
+        result = view("/anything", {}, start_response)
+
+        assert result is None
+        start_response.assert_not_called()
+
+    def test_it_triggers_for_routing_urls(self, start_response):
+        host = "http://example.com"
+
+        view = RoutingView(routing_host=host)
+        result = view("/", {}, start_response)
+
+        assert result == []
+        start_response.assert_called_once_with(
+            "307 Temporary Redirect",
+            [
+                ("Location", f"{host}/"),
+                (
+                    "Cache-Control",
+                    Any.string.matching(
+                        r"public, max-age=\d+, stale-while-revalidate=\d+"
+                    ),
+                ),
+            ],
+        )

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -9,6 +9,7 @@ from werkzeug.wsgi import get_path_info
 from viahtml.hooks import Hooks
 from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks
 from viahtml.views.blocklist import BlocklistView
+from viahtml.views.routing import RoutingView
 from viahtml.views.status import StatusView
 
 
@@ -22,7 +23,11 @@ class Application:
         self._setup_logging(config["debug"])
         self.hooks = Hooks(config)
 
-        self.views = (StatusView(), BlocklistView(config["blocklist"]))
+        self.views = (
+            StatusView(),
+            BlocklistView(config["blocklist"]),
+            RoutingView(config["routing_host"]),
+        )
 
         # Setup hook points and apply those which must be done pre-application
         apply_pre_app_hooks(self.hooks)
@@ -68,6 +73,7 @@ class Application:
             "h_embed_url": os.environ["VIA_H_EMBED_URL"],
             "debug": os.environ.get("VIA_DEBUG", False),
             "blocklist": os.environ["VIA_BLOCKLIST_PATH"],
+            "routing_host": os.environ["VIA_ROUTING_HOST"],
         }
 
     @classmethod

--- a/viahtml/blocklist.py
+++ b/viahtml/blocklist.py
@@ -54,7 +54,6 @@ class Blocklist:
         self._refresh()
 
         domain = self._domain(url)
-        self.LOG.debug("DOMAIN? %s: %s", domain, self.domains)
         return self.domains.get(domain, False)
 
     @classmethod

--- a/viahtml/views/routing.py
+++ b/viahtml/views/routing.py
@@ -1,0 +1,47 @@
+"""Handle requests from the root for routing."""
+
+
+class RoutingView:
+    """A view for routing content (by handing it off to Via proper)."""
+
+    # Cache control values lifted from Via route_by_content for the values it
+    # returns. I figure we are good to match them.
+    MAX_AGE = 300
+    STALE_WHILE_REVALIDATE = 86400
+
+    def __init__(self, routing_host):
+        """Create a view for routing requests to present content.
+
+        Currently we don't do routing ourselves, but just pass it off to the
+        main Via component to do for us.
+
+        :param routing_host: The host which will actually do the routing
+        """
+        self._routing_host = routing_host
+
+    def __call__(self, path, environ, start_response):
+        """Redirect to the content based routing service if required.
+
+        :param path: The url path of the request
+        :param environ: WSGI environ dict
+        :param start_response: WSGI `start_response()` function
+        :return: An iterator of content if required or None
+        """
+        if path != "/":
+            return None
+
+        location = f"{self._routing_host.rstrip('/')}/"
+        cache_control = ", ".join(
+            [
+                "public",
+                f"max-age={self.MAX_AGE}",
+                f"stale-while-revalidate={self.STALE_WHILE_REVALIDATE}",
+            ]
+        )
+
+        start_response(
+            "307 Temporary Redirect",
+            [("Location", location), ("Cache-Control", cache_control)],
+        )
+
+        return []


### PR DESCRIPTION
For https://github.com/hypothesis/via3/issues/285

This adds a landing page for ViaHTML. This works by:

 * ~Having static HTML content served from root~
 * ~That content redirects to `/route/?url=`~
 * ~We have a "view" that catches this, reads the env var `VIA_ROUTING_HOST` and redirects there~
 * ~This will be Via 3 for now~

~This means the host can change via ENV var, but we can still serve the same static HTML content.~

Sean correctly pointed out this is dumb. How this now works:

 * If you go to "/" this is picked up by a view
 * This reads the env var `VIA_ROUTING_HOST` and redirects to the root there

## Testing notes

 * Run via, via3 and viahtml with `make dev`
 * Goto: http://localhost:9085 (viahtml)
 * You should end up redirected to Via 3 on http://localhost:9083 and see the landing page