### PR TITLE
Support "views" with no body and pass in the path

### DIFF
--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -110,9 +110,11 @@ class TestApplication:
         modified_outbound.assert_called_once_with(self.HEADERS)
         start_response.assert_called_with(Any(), modified_outbound.return_value)
 
-    def test_it_applies_views(self, view, app, start_response, environ):
+    @pytest.mark.parametrize("return_value", (["Hello"], []))
+    # pylint: disable=too-many-arguments
+    def test_it_applies_views(self, view, app, start_response, environ, return_value):
         environ["PATH_INFO"] = "/path"
-        view.return_value = ["Hello"]
+        view.return_value = return_value
 
         result = app(environ, start_response)
 

--- a/tests/unit/viahtml/app_test.py
+++ b/tests/unit/viahtml/app_test.py
@@ -111,11 +111,12 @@ class TestApplication:
         start_response.assert_called_with(Any(), modified_outbound.return_value)
 
     def test_it_applies_views(self, view, app, start_response, environ):
+        environ["PATH_INFO"] = "/path"
         view.return_value = ["Hello"]
 
         result = app(environ, start_response)
 
-        view.assert_called_once_with(environ, start_response)
+        view.assert_called_once_with("/path", environ, start_response)
         assert result == view.return_value
 
     def test_it_does_not_apply_views_if_they_have_no_return_value(
@@ -129,7 +130,9 @@ class TestApplication:
 
     @pytest.fixture
     def view(self, app):
-        view = create_autospec(lambda environ, start_response: None)  # pragma: no cover
+        view = create_autospec(
+            lambda path, environ, start_response: None
+        )  # pragma: no cover
         view.return_value = None
         app.views = [view]
 

--- a/tests/unit/viahtml/views/blocklist_test.py
+++ b/tests/unit/viahtml/views/blocklist_test.py
@@ -22,11 +22,11 @@ class TestBlocklistView:
         ),
     )
     def test_it_extracts_the_url_correctly(self, path, expected):
-        proxied_url = BlocklistView.get_proxied_url({"PATH_INFO": path})
+        proxied_url = BlocklistView.get_proxied_url(path)
         assert proxied_url == expected
 
     def test_if_there_is_no_url_it_does_nothing(self, view, start_response):
-        result = view({"PATH_INFO": ""}, start_response)
+        result = view("", {}, start_response)
 
         assert result is None
         view.blocklist.assert_not_called()
@@ -34,7 +34,7 @@ class TestBlocklistView:
     def test_if_the_url_is_not_blocked_it_does_nothing(self, view, start_response):
         view.blocklist.is_blocked.return_value = None
 
-        result = view({"PATH_INFO": "/proxy/http://example.com"}, start_response)
+        result = view("/proxy/http://example.com", {}, start_response)
 
         assert result is None
         view.blocklist.is_blocked.assert_called_once_with("http://example.com")
@@ -50,7 +50,7 @@ class TestBlocklistView:
     def test_blocking(self, view, block_reason, start_response, expected_heading):
         view.blocklist.is_blocked.return_value = block_reason
 
-        result = view({"PATH_INFO": "/proxy/http://example.com"}, start_response)
+        result = view("/proxy/http://example.com", {}, start_response)
 
         start_response.assert_called_once_with(
             "403 Forbidden", [("Content-Type", "text/html; charset=utf-8")]

--- a/tests/unit/viahtml/views/status_test.py
+++ b/tests/unit/viahtml/views/status_test.py
@@ -16,12 +16,12 @@ class TestStatusView:
         ),
     )
     def test_it_responds_to_the_status_url(self, path, responds, start_response):
-        response = StatusView()({"PATH_INFO": path}, start_response)
+        response = StatusView()(path, {}, start_response)
 
         assert bool(response) == responds
 
     def test_it_returns_the_expected_response(self, start_response):
-        response = StatusView()({"PATH_INFO": "/_status"}, start_response)
+        response = StatusView()("/_status", {}, start_response)
 
         start_response.assert_called_once_with(
             "200 OK",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ filterwarnings =
     ignore:the imp module is deprecated in favour of importlib
     ; Annoying errors raised in pywb.rewrite.cookie_rewriter
     ignore:invalid escape sequence
+    ; Mostly from importing pywb.apps.frontendapp.FrontEndApp
+    ignore:Monkey-patching ssl after ssl has already been imported may lead to errors.*:gevent.monkey.MonkeyPatchWarning:
 
 xfail_strict=true
 

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -4,6 +4,7 @@ import os
 
 from pkg_resources import resource_filename
 from pywb.apps.frontendapp import FrontEndApp
+from werkzeug.wsgi import get_path_info
 
 from viahtml.hooks import Hooks
 from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks
@@ -35,7 +36,8 @@ class Application:
         """Handle WSGI requests."""
 
         for view in self.views:
-            response = view(environ, start_response)
+            path = get_path_info(environ)
+            response = view(path, environ, start_response)
             if response:
                 return response
 

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -38,7 +38,7 @@ class Application:
         for view in self.views:
             path = get_path_info(environ)
             response = view(path, environ, start_response)
-            if response:
+            if response is not None:
                 return response
 
         # Looks like it's a normal request to proxy...

--- a/viahtml/views/blocklist.py
+++ b/viahtml/views/blocklist.py
@@ -5,7 +5,6 @@ import re
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pkg_resources import resource_filename
-from werkzeug.wsgi import get_path_info
 
 from viahtml.blocklist import Blocklist
 
@@ -26,9 +25,8 @@ class BlocklistView:
         self.blocklist = Blocklist(file_name)
 
     @classmethod
-    def get_proxied_url(cls, environ):
+    def get_proxied_url(cls, path):
         """Get the proxied URL from a WSGI environment variable."""
-        path = get_path_info(environ)
 
         match = cls.PROXY_PATTERN.match(path)
         if match:
@@ -36,14 +34,15 @@ class BlocklistView:
 
         return None
 
-    def __call__(self, environ, start_response):
+    def __call__(self, path, environ, start_response):
         """Provide a block page response if required.
 
+        :param path: The url path of the request
         :param environ: WSGI environ dict
         :param start_response: WSGI `start_response()` function
         :return: An iterator of content if required or None
         """
-        url = self.get_proxied_url(environ)
+        url = self.get_proxied_url(path)
         if not url:
             return None
 

--- a/viahtml/views/status.py
+++ b/viahtml/views/status.py
@@ -2,22 +2,19 @@
 
 import json
 
-from werkzeug.wsgi import get_path_info
-
 
 class StatusView:
     """Status end-point."""
 
-    def __call__(self, environ, start_response):
+    def __call__(self, path, environ, start_response):
         """Provide a status response if required.
 
+        :param path: The url path of the request
         :param environ: WSGI environ dict
         :param start_response: WSGI `start_response()` function
         :return: An iterator of content if required or None
         """
-        path = get_path_info(environ).rstrip("/")
-
-        if path != "/_status":
+        if path.rstrip("/") != "/_status":
             # We don't want to handle this call
             return None
 


### PR DESCRIPTION
In preparation for adding a third view some patterns have emerged:

 * All the views want to know what the path is
 * Not all of the views return something "truthy" when replying

The new path for the landing page will issue a redirect, which won't have any body