### PR TITLE
Share environment variables between tests and functests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+def environment_variables():
+    return {
+        "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
+        "VIA_IGNORE_PREFIXES": ",".join(
+            [
+                "http://localhost:5000/",
+                "http://localhost:3001/",
+                "https://localhost:5000/",
+                "https://localhost:3001/",
+            ]
+        ),
+        "VIA_DEBUG": "1",
+        "VIA_BLOCKLIST_FILE": "../conf/blocklist-dev.txt",
+    }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import webtest
 
+from tests.conftest import environment_variables
 from tests.simple_server import serve_content
 from viahtml.app import Application
 
@@ -20,21 +21,7 @@ def with_environ():
     # WSGI uses repeated elements to express this, which means we can't use
     # the standard configparser.ConfigParser to read them. So they are
     # duplicated here:
-    os.environ.update(
-        {
-            "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
-            "VIA_IGNORE_PREFIXES": ",".join(
-                [
-                    "http://localhost:5000/",
-                    "http://localhost:3001/",
-                    "https://localhost:5000/",
-                    "https://localhost:3001/",
-                ]
-            ),
-            "VIA_DEBUG": "1",
-            "VIA_BLOCKLIST_FILE": "../conf/blocklist-dev.txt",
-        }
-    )
+    os.environ.update(environment_variables())
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,8 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from tests.conftest import environment_variables
+
 
 def _autopatcher(request, target, **kwargs):
     """Patch and cleanup automatically. Wraps :py:func:`mock.patch`."""
@@ -23,16 +25,7 @@ def patch(request):
 @pytest.fixture
 def os():
     with mock.patch("viahtml.app.os", autospec=True) as os:
-        os.environ = {
-            "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
-            "VIA_IGNORE_PREFIXES": (
-                # This is one string
-                "http://localhost:5000/,http://localhost:3001/,"
-                "https://localhost:5000/,https://localhost:3001/"
-            ),
-            "VIA_DEBUG": "1",
-            "VIA_BLOCKLIST_FILE": "../conf/blocklist-dev.txt",
-        }
+        os.environ = environment_variables()
         yield os
 
 


### PR DESCRIPTION
Previously we had two (diverging) copies of the same logic. This makes it easier to add new things to it.

This _isn't_ a pytest fixture, as it's needed in a session scoped fixtured for the functional tests and a per test fixture in the other. I was a bit concerned that tests could mess with it and have cross contamination.