### PR TITLE
Report detailed stats from uWSGI to New Relic

### DIFF
--- a/bin/report_metrics.py
+++ b/bin/report_metrics.py
@@ -1,0 +1,39 @@
+"""Collect stats from uWSGI and send them to New Relic."""
+
+import logging
+import sys
+from time import sleep
+
+import newrelic.agent
+from pkg_resources import resource_filename
+
+from viahtml.stats import UWSGINewRelicStatsGenerator
+
+METRICS_INTERVAL = 60
+LOG = logging.getLogger(__name__)
+# If you set this to DEBUG, you get a lot of New Relic info in there, but it
+# can be useful locally
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+
+def _report_stats():
+    # Read metrics from the stats end-point of uWSGI
+
+    newrelic.agent.initialize(
+        config_file=resource_filename("viahtml", "../conf/newrelic.ini")
+    )
+    newrelic.agent.register_application(timeout=5)
+    application = newrelic.agent.application()
+
+    generate_stats = UWSGINewRelicStatsGenerator(stats_endpoint="http://localhost:3033")
+
+    while True:
+        application.record_custom_metrics(generate_stats())
+        sleep(METRICS_INTERVAL)
+
+
+if __name__ == "__main__":
+    try:
+        _report_stats()
+    finally:
+        LOG.fatal("ViaHTML metrics collection has stopped un-expectedly")

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -97,3 +97,8 @@ py-autoreload = true
 
 mount = /=viahtml/wsgi.py
 uwsgi-socket = 0.0.0.0:3032
+
+stats =  0.0.0.0:3033
+stats-http = true
+stats-no-cores = true
+stats-minified = true

--- a/conf/newrelic.ini
+++ b/conf/newrelic.ini
@@ -1,0 +1,210 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+#license_key = <This will be read from the environment variable>
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+#app_name = <This will be read from the environment variable>
+
+# New Relic offers distributed tracing for monitoring and analyzing modern
+# distributed systems.Enable distributed tracing.
+distributed_tracing.enabled = true
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+#log_file = /tmp/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = viahtml (Staging)
+monitor_mode = true
+
+[newrelic:production]
+monitor_mode = true
+
+# ---------------------------------------------------------------------------

--- a/conf/newrelic.ini
+++ b/conf/newrelic.ini
@@ -121,7 +121,7 @@ high_security = false
 # transactions and sends this to the UI on a periodic basis. The
 # transaction tracer is enabled by default. Set this to "false"
 # to turn it off.
-transaction_tracer.enabled = true
+transaction_tracer.enabled = false
 
 # Threshold in seconds for when to collect a transaction trace.
 # When the response time of a controller action exceeds this
@@ -164,7 +164,7 @@ transaction_tracer.function_trace =
 # exceptions or logged exceptions and sends them to UI for
 # viewing. The error collector is enabled by default. Set this
 # to "false" to turn it off.
-error_collector.enabled = true
+error_collector.enabled = false
 
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
@@ -175,14 +175,14 @@ error_collector.ignore_errors =
 # For those Python web frameworks that are supported, this
 # setting enables the auto-insertion of the browser monitoring
 # JavaScript fragments.
-browser_monitoring.auto_instrument = true
+browser_monitoring.auto_instrument = false
 
 # A thread profiling session can be scheduled via the UI when
 # this option is enabled. The thread profiler will periodically
 # capture a snapshot of the call stack for each active thread in
 # the application to construct a statistically representative
 # call tree.
-thread_profiler.enabled = true
+thread_profiler.enabled = false
 
 # ---------------------------------------------------------------------------
 

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -90,3 +90,8 @@ py-tracebacker = /tmp/via-traceback-
 
 mount = /=viahtml/wsgi.py
 uwsgi-socket = /tmp/viahtml-uwsgi.sock
+
+stats =  0.0.0.0:3033
+stats-http = true
+stats-no-cores = true
+stats-minified = true

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -18,6 +18,13 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:report_metrics]
+command=python bin/report_metrics.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
 [eventlistener:logger]
 command=bin/logger --dev
 buffer_size=100

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -20,6 +20,13 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:report_metrics]
+command=python bin/report_metrics.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled=true
+stderr_events_enabled=true
+
 [eventlistener:logger]
 command=bin/logger
 buffer_size=100

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,4 +5,3 @@ ipython
 ipdb
 docker-compose
 supervisor
-newrelic

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -2,4 +2,4 @@ pytest
 webtest
 httpretty
 responses
-h-matchers
+h-matchers>=1.2.10

--- a/tests/unit/viahtml/stats_test.json
+++ b/tests/unit/viahtml/stats_test.json
@@ -1,0 +1,259 @@
+{
+    "version": "2.0.19.1",
+    "listen_queue": 12,
+    "listen_queue_errors": 13,
+    "signal_queue": 14,
+    "load": 16,
+    "pid": 7692,
+    "uid": 1000,
+    "gid": 1000,
+    "cwd": "/blah/viahtml/viahtml",
+    "locks": [
+        {
+            "user 0": 0
+        },
+        {
+            "signal": 0
+        },
+        {
+            "filemon": 0
+        },
+        {
+            "timer": 0
+        },
+        {
+            "rbtimer": 0
+        },
+        {
+            "cron": 0
+        },
+        {
+            "rpc": 0
+        },
+        {
+            "snmp": 0
+        }
+    ],
+    "sockets": [
+        {
+            "name": "0.0.0.0:3032",
+            "proto": "uwsgi",
+            "queue": 17,
+            "max_queue": 100,
+            "shared": 18,
+            "can_offload": 0
+        }
+    ],
+    "workers": [
+        {
+            "id": 1,
+            "pid": 0,
+            "accepting": 1,
+            "requests": 12,
+            "delta_requests": 0,
+            "exceptions": 5,
+            "harakiri_count": 1,
+            "signals": 0,
+            "signal_queue": 19,
+            "status": "cheap",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 0,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 0,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "pid": 0,
+            "accepting": 1,
+            "requests": 0,
+            "delta_requests": 0,
+            "exceptions": 0,
+            "harakiri_count": 0,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "cheap",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 0,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 0,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 3,
+            "pid": 0,
+            "accepting": 1,
+            "requests": 0,
+            "delta_requests": 0,
+            "exceptions": 0,
+            "harakiri_count": 2,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "cheap",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 0,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 345,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 4,
+            "pid": 0,
+            "accepting": 1,
+            "requests": 2,
+            "delta_requests": 2,
+            "exceptions": 0,
+            "harakiri_count": 0,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "cheap",
+            "rss": 45858816,
+            "vsz": 766259200,
+            "running_time": 354560,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 6920,
+            "avg_rt": 176700,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 2,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 5,
+            "pid": 7822,
+            "accepting": 1,
+            "requests": 0,
+            "delta_requests": 0,
+            "exceptions": 2,
+            "harakiri_count": 4,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "cheap",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 0,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 0,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 6,
+            "pid": 7825,
+            "accepting": 0,
+            "requests": 0,
+            "delta_requests": 0,
+            "exceptions": 0,
+            "harakiri_count": 0,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "cheap",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 0,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 0,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        },
+        {
+            "id": 7,
+            "pid": 7826,
+            "accepting": 0,
+            "requests": 0,
+            "delta_requests": 0,
+            "exceptions": 0,
+            "harakiri_count": 0,
+            "signals": 0,
+            "signal_queue": 0,
+            "status": "idle",
+            "rss": 3195,
+            "vsz": 0,
+            "running_time": 323984,
+            "last_spawn": 1604059705,
+            "respawn_count": 1,
+            "tx": 0,
+            "avg_rt": 2345,
+            "apps": [
+                {
+                    "id": 0,
+                    "modifier1": 0,
+                    "mountpoint": "/",
+                    "startup_time": 1,
+                    "requests": 0,
+                    "exceptions": 0,
+                    "chdir": ""
+                }
+            ]
+        }
+    ]
+}

--- a/tests/unit/viahtml/stats_test.py
+++ b/tests/unit/viahtml/stats_test.py
@@ -1,0 +1,148 @@
+import json
+
+import pytest
+from h_matchers import Any
+from pkg_resources import resource_filename
+from requests import RequestException
+
+from viahtml.stats import UWSGINewRelicStatsGenerator
+
+STATS_ENDPOINT = "http://example.com"
+
+
+class TestUWSGINewRelicStatsGenerator:
+    def test_it_calls_the_end_point_and_returns_stats(self, stats, requests):
+        results = list(stats())
+
+        requests.get.assert_called_once_with(url=STATS_ENDPOINT, timeout=1)
+
+        assert results == Any.list.containing([("Custom/Alive/Metrics", 1)])
+
+    def test_it_returns_basic_stats_when_the_request_fails(self, stats, requests):
+        requests.get.side_effect = RequestException
+
+        results = list(stats())
+
+        assert (
+            results
+            == Any.list.containing(
+                [("Custom/Alive/Metrics", 1), ("Custom/Alive/App", 0)]
+            ).only()
+        )
+
+    def test_return_values_golden_master(self, stats):
+        # A golden master style test to attempt to check that the system hasn't
+        # gone catastrophically wrong without writing an un-due amount of test
+        # code for this.
+        # https://en.wikipedia.org/wiki/Characterization_test
+
+        # This compares a fixed input with a known good output. It's generated
+        # exactly as you'd expect by running the test backwards. However the
+        # original source has been modified for better tests by varying values
+        # to ensure the system is exercised.
+
+        # As this isn't unit-style failures in this test are a canary in a coal
+        # mine style results, and help you know that something is wrong, but
+        # not what.
+
+        results = list(stats())
+
+        print(results)
+
+        # To maintain these tests when things change print out results, examine
+        # them and then set them to expected if they look good
+        expected = [
+            ("Custom/Alive/Metrics", 1),
+            ("Custom/Alive/App", 1),
+            ("Custom/System/Load", 16),
+            ("Custom/ListenQueue/Size", 12),
+            ("Custom/ListenQueue/Errors", 13),
+            ("Custom/SignalQueue/Size", 14),
+            (
+                "Custom/Socket/Queue/Size",
+                {"total": 17, "count": 1, "min": 17, "max": 17, "sum_of_squares": 289},
+            ),
+            (
+                "Custom/Socket/Queue/Max",
+                {
+                    "total": 100,
+                    "count": 1,
+                    "min": 100,
+                    "max": 100,
+                    "sum_of_squares": 10000,
+                },
+            ),
+            ("Custom/Worker/Count/Accepting", 5),
+            ("Custom/Worker/Count/Max", 7),
+            (
+                "Custom/Worker/Request/Total",
+                {"total": 14, "count": 5, "min": 0, "max": 12, "sum_of_squares": 148},
+            ),
+            (
+                "Custom/Worker/Request/Failed",
+                {"total": 7, "count": 5, "min": 0, "max": 5, "sum_of_squares": 29},
+            ),
+            (
+                "Custom/Worker/Killed",
+                {"total": 7, "count": 5, "min": 0, "max": 4, "sum_of_squares": 21},
+            ),
+            (
+                "Custom/Worker/Memory/Resident[kB]",
+                {
+                    "total": 44796.48,
+                    "count": 5,
+                    "min": 3.12,
+                    "max": 44784.0,
+                    "sum_of_squares": 2005606694,
+                },
+            ),
+            (
+                "Custom/Worker/AverageResponseTime[ms]",
+                {
+                    "total": 177.04,
+                    "count": 2,
+                    "min": 0.34,
+                    "max": 176.7,
+                    "sum_of_squares": 31223,
+                },
+            ),
+            (
+                "Custom/Worker/UpTime[ms]",
+                {
+                    "total": 354.56,
+                    "count": 1,
+                    "min": 354.56,
+                    "max": 354.56,
+                    "sum_of_squares": 125712,
+                },
+            ),
+            (
+                "Custom/Worker/Memory/Virtual[kB]",
+                {
+                    "total": 748300.0,
+                    "count": 1,
+                    "min": 748300.0,
+                    "max": 748300.0,
+                    "sum_of_squares": 559952890000,
+                },
+            ),
+        ]
+
+        for metric_name, value in expected:
+            assert (metric_name, value) in results
+
+    @pytest.fixture
+    def stats(self):
+        return UWSGINewRelicStatsGenerator(stats_endpoint=STATS_ENDPOINT)
+
+    @pytest.fixture
+    def json_response(self):
+        with open(resource_filename("tests", "unit/viahtml/stats_test.json")) as handle:
+            return json.load(handle)
+
+    @pytest.fixture(autouse=True)
+    def requests(self, patch, json_response):
+        requests = patch("viahtml.stats.requests")
+        requests.get.return_value.json.return_value = json_response
+
+        return requests

--- a/tests/unit/viahtml/stats_test.py
+++ b/tests/unit/viahtml/stats_test.py
@@ -12,20 +12,19 @@ STATS_ENDPOINT = "http://example.com"
 
 class TestUWSGINewRelicStatsGenerator:
     def test_it_calls_the_end_point_and_returns_stats(self, stats, requests):
-        results = list(stats())
+        results = stats()
 
+        assert results == Any.generator.containing([("Custom/Alive/Metrics", 1)])
         requests.get.assert_called_once_with(url=STATS_ENDPOINT, timeout=1)
-
-        assert results == Any.list.containing([("Custom/Alive/Metrics", 1)])
 
     def test_it_returns_basic_stats_when_the_request_fails(self, stats, requests):
         requests.get.side_effect = RequestException
 
-        results = list(stats())
+        results = stats()
 
         assert (
             results
-            == Any.list.containing(
+            == Any.generator.containing(
                 [("Custom/Alive/Metrics", 1), ("Custom/Alive/App", 0)]
             ).only()
         )

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ setenv =
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: VIA_BLOCKLIST_PATH = conf/blocklist-dev.txt
+    dev: NEW_RELIC_APP_NAME = viahtml
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 passenv =
     HOME
@@ -41,6 +42,7 @@ passenv =
     dev: NGINX_SERVER
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
+    dev: NEW_RELIC_LICENSE_KEY
 deps =
     dev: -r requirements-dev.in
     tests: coverage

--- a/viahtml/stats.py
+++ b/viahtml/stats.py
@@ -25,13 +25,24 @@ class UWSGINewRelicStatsGenerator:
     }
 
     WORKER_STATS = {
-        "avg_rt": "Worker/AverageResponseTime",
+        "avg_rt": "Worker/AverageResponseTime[ms]",
         "requests": "Worker/Request/Total",
         "exceptions": "Worker/Request/Failed",
         "harakiri_count": "Worker/Killed",
-        "running_time": "Worker/UpTime",
-        "rss": "Worker/Memory/Resident",
-        "vsz": "Worker/Memory/Virtual",
+        "running_time": "Worker/UpTime[ms]",
+        "rss": "Worker/Memory/Resident[kB]",
+        "vsz": "Worker/Memory/Virtual[kB]",
+    }
+    # Don't include zeros in these numbers as they reflect the worker being
+    # inactive and artificially bring down the average
+    WORKER_PRUNE_ZEROS = ("avg_rt", "running_time", "rss", "vsz")
+    WORKER_SCALE_STATS = {
+        # From micro-seconds to milliseconds
+        "avg_rt": 1 / 1000,
+        "running_time": 1 / 1000,
+        # From bytes to kilobytes
+        "rss": 1 / 1024,
+        "vsz": 1 / 1024,
     }
 
     SOCKET_STATS = {
@@ -58,7 +69,7 @@ class UWSGINewRelicStatsGenerator:
         yield "Alive/Metrics", 1
 
         try:
-            raw_stats = requests.get(self._stats_endpoint).json()
+            raw_stats = requests.get(url=self._stats_endpoint, timeout=1).json()
         except RequestException as err:
             LOG.debug("Stats collection from uWSGI failed with error: %s", err)
 
@@ -72,37 +83,58 @@ class UWSGINewRelicStatsGenerator:
             yield stat_name, raw_stats[key]
 
         # Socket metrics
-        yield from self._stats_from_items(raw_stats["sockets"], self.SOCKET_STATS)
+        yield from self._stats_from_items(
+            raw_stats["sockets"], stat_mapping=self.SOCKET_STATS
+        )
 
-        # Worker metrics
+        yield from self._get_worker_stats(raw_stats)
+
+    def _get_worker_stats(self, raw_stats):
         workers = raw_stats["workers"]
         accepting_workers = [worker for worker in workers if worker["accepting"]]
 
         yield "Worker/Count/Accepting", len(accepting_workers)
         yield "Worker/Count/Max", len(workers)
 
-        yield from self._stats_from_items(accepting_workers, self.WORKER_STATS)
+        yield from self._stats_from_items(
+            accepting_workers,
+            stat_mapping=self.WORKER_STATS,
+            prune_zero=self.WORKER_PRUNE_ZEROS,
+            scale_stats=self.WORKER_SCALE_STATS,
+        )
 
     @classmethod
-    def _stats_from_items(cls, items, stat_mapping):
+    def _stats_from_items(cls, items, stat_mapping, prune_zero=None, scale_stats=None):
         """Map a list of dicts into a set of stats.
 
         :param items: Data items to map
         :param stat_mapping: Mapping from keys to New Relic metric name
+        :param prune_zero: Remove zeros from these keys
+        :param scale_stats: Scale these stats by the given number
         """
         stats = defaultdict(list)
 
         # Turn the individual dicts into a single dict with lists of values
         for item in items:
             for key, stat_name in stat_mapping.items():
-                stats[stat_name].append(item[key])
+                value = item[key]
+                if not value and prune_zero and key in prune_zero:
+                    continue
+
+                if scale_stats and key in scale_stats:
+                    # Give two decimal places of accuracy
+                    value = int(100 * value * scale_stats[key]) / 100
+
+                stats[stat_name].append(value)
 
         # Summarise those lists of values
         for stat_name, values in stats.items():
             yield stat_name, {
                 "total": sum(values),
+                "count": len(values),
                 "min": min(values),
                 "max": max(values),
-                "sum_of_squares": sum(value ** 2 for value in values),
-                "count": len(values),
+                # Squash this to the nearest int for repeatability in the tests
+                # It'll be close enough for metrics purposes
+                "sum_of_squares": int(sum(value ** 2 for value in values)),
             }

--- a/viahtml/stats.py
+++ b/viahtml/stats.py
@@ -1,0 +1,108 @@
+"""uWSGI -> New Relic metrics collection logic."""
+
+from collections import defaultdict
+from logging import getLogger
+
+import requests
+from requests import RequestException
+
+LOG = getLogger(__name__)
+
+
+# pylint: disable=missing-yield-doc,missing-yield-type-doc
+
+
+class UWSGINewRelicStatsGenerator:
+    """A callable which returns stats from uWSGI stats for New Relic."""
+
+    # Mappings from various parts of the JSON structure we get back from
+    # uWSGI stats end-point to some suitable metrics names for New Relic
+    ROOT_STATS = {
+        "load": "System/Load",
+        "listen_queue": "ListenQueue/Size",
+        "listen_queue_errors": "ListenQueue/Errors",
+        "signal_queue": "SignalQueue/Size",
+    }
+
+    WORKER_STATS = {
+        "avg_rt": "Worker/AverageResponseTime",
+        "requests": "Worker/Request/Total",
+        "exceptions": "Worker/Request/Failed",
+        "harakiri_count": "Worker/Killed",
+        "running_time": "Worker/UpTime",
+        "rss": "Worker/Memory/Resident",
+        "vsz": "Worker/Memory/Virtual",
+    }
+
+    SOCKET_STATS = {
+        "queue": "Socket/Queue/Size",
+        "max_queue": "Socket/Queue/Max",
+    }
+
+    def __init__(self, stats_endpoint):
+        """Create a callable metrics generator.
+
+        :param stats_endpoint: The uWSGI stats end-point to call
+        """
+        self._stats_endpoint = stats_endpoint
+
+    def __call__(self):
+        """Generate stat name value pairs."""
+
+        for stat_name, values in self._get_stats():
+            LOG.debug("Reporting stat %s = %s", stat_name, values)
+            yield f"Custom/{stat_name}", values
+
+    def _get_stats(self):
+        # General "I'm alive!" type stuff
+        yield "Alive/Metrics", 1
+
+        try:
+            raw_stats = requests.get(self._stats_endpoint).json()
+        except RequestException as err:
+            LOG.debug("Stats collection from uWSGI failed with error: %s", err)
+
+            yield "Alive/App", 0
+            return
+
+        yield "Alive/App", 1
+
+        # General metrics
+        for key, stat_name in self.ROOT_STATS.items():
+            yield stat_name, raw_stats[key]
+
+        # Socket metrics
+        yield from self._stats_from_items(raw_stats["sockets"], self.SOCKET_STATS)
+
+        # Worker metrics
+        workers = raw_stats["workers"]
+        accepting_workers = [worker for worker in workers if worker["accepting"]]
+
+        yield "Worker/Count/Accepting", len(accepting_workers)
+        yield "Worker/Count/Max", len(workers)
+
+        yield from self._stats_from_items(accepting_workers, self.WORKER_STATS)
+
+    @classmethod
+    def _stats_from_items(cls, items, stat_mapping):
+        """Map a list of dicts into a set of stats.
+
+        :param items: Data items to map
+        :param stat_mapping: Mapping from keys to New Relic metric name
+        """
+        stats = defaultdict(list)
+
+        # Turn the individual dicts into a single dict with lists of values
+        for item in items:
+            for key, stat_name in stat_mapping.items():
+                stats[stat_name].append(item[key])
+
+        # Summarise those lists of values
+        for stat_name, values in stats.items():
+            yield stat_name, {
+                "total": sum(values),
+                "min": min(values),
+                "max": max(values),
+                "sum_of_squares": sum(value ** 2 for value in values),
+                "count": len(values),
+            }


### PR DESCRIPTION
How does this work?

 * uWSGI can be configured to expose a JSON stats end-point (https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html)
 * This has been configured to port 3033 (I tried a file socket, but it's no quicker and more annoying)
 * We run a script which periodically reads from this
 * This converts the various values into the format New Relic expects and sends it on it's way
 * This is run as a separate process by `supervisord`

### Testing notes

 * You need your own New Relic account (which you probably have by default)
 * Get your license and run `export NEW_RELIC_LICENSE_KEY=<...>`
 * `make dev`
 * You should eventually see some stats go into New Relic

### Review notes

 * A lot of this PR is:
   * A config file generated by New Relic
   * A big fixture example of uWSGI output
 * The approach here is basically the same as in `h.streamer`
 * I tried registering a data source and letting New Relic get on with it, which sort of works, but the data coming back was totally patchy