### PR TITLE
Set the python path so the metrics script can find `viahtml`

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -21,6 +21,7 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:report_metrics]
+environment=PYTHONPATH=.
 command=python bin/report_metrics.py
 stdout_logfile=NONE
 stderr_logfile=NONE


### PR DESCRIPTION
Previously we were getting:

```
2020-10-30 13:42:52,622 INFO spawned: 'report_metrics' with pid 73
report_metrics (stderr) | Traceback (most recent call last):
report_metrics (stderr) |   File "bin/report_metrics.py", line 10, in <module>
report_metrics (stderr) |     from viahtml.stats import UWSGINewRelicStatsGenerator
report_metrics (stderr) | ModuleNotFoundError: No module named 'viahtml'
```

To test:

 * `make docker`
 * `make run-docker`

If you want to actually test the metrics you will need to: `export NEW_RELIC_LICENSE_KEY=<your key here>`