### PR TITLE
Try kilobytes instead of kB to see if New Relic understands

### DIFF
--- a/tests/unit/viahtml/stats_test.py
+++ b/tests/unit/viahtml/stats_test.py
@@ -46,8 +46,6 @@ class TestUWSGINewRelicStatsGenerator:
 
         results = list(stats())
 
-        print(results)
-
         # To maintain these tests when things change print out results, examine
         # them and then set them to expected if they look good
         expected = [
@@ -86,13 +84,13 @@ class TestUWSGINewRelicStatsGenerator:
                 {"total": 7, "count": 5, "min": 0, "max": 4, "sum_of_squares": 21},
             ),
             (
-                "Custom/Worker/Memory/Resident[kB]",
+                "Custom/Worker/Memory/Resident[kiloBytes]",
                 {
-                    "total": 44796.48,
+                    "total": 45871.57,
                     "count": 5,
-                    "min": 3.12,
-                    "max": 44784.0,
-                    "sum_of_squares": 2005606694,
+                    "min": 3.19,
+                    "max": 45858.81,
+                    "sum_of_squares": 2103030495,
                 },
             ),
             (
@@ -116,13 +114,13 @@ class TestUWSGINewRelicStatsGenerator:
                 },
             ),
             (
-                "Custom/Worker/Memory/Virtual[kB]",
+                "Custom/Worker/Memory/Virtual[kiloBytes]",
                 {
-                    "total": 748300.0,
+                    "total": 766259.2,
                     "count": 1,
-                    "min": 748300.0,
-                    "max": 748300.0,
-                    "sum_of_squares": 559952890000,
+                    "min": 766259.2,
+                    "max": 766259.2,
+                    "sum_of_squares": 587153161584,
                 },
             ),
         ]

--- a/viahtml/stats.py
+++ b/viahtml/stats.py
@@ -30,8 +30,8 @@ class UWSGINewRelicStatsGenerator:
         "exceptions": "Worker/Request/Failed",
         "harakiri_count": "Worker/Killed",
         "running_time": "Worker/UpTime[ms]",
-        "rss": "Worker/Memory/Resident[kB]",
-        "vsz": "Worker/Memory/Virtual[kB]",
+        "rss": "Worker/Memory/Resident[kiloBytes]",
+        "vsz": "Worker/Memory/Virtual[kiloBytes]",
     }
     # Don't include zeros in these numbers as they reflect the worker being
     # inactive and artificially bring down the average
@@ -41,8 +41,8 @@ class UWSGINewRelicStatsGenerator:
         "avg_rt": 1 / 1000,
         "running_time": 1 / 1000,
         # From bytes to kilobytes
-        "rss": 1 / 1024,
-        "vsz": 1 / 1024,
+        "rss": 1 / 1000,
+        "vsz": 1 / 1000,
     }
 
     SOCKET_STATS = {


### PR DESCRIPTION
There doesn't appear to be a list of metrics that New Relic understands, but some values clearly have a special meaning. "ms" for instance seems to be understood correctly.

The docs have examples which mention "kilobytes" as the unit, so maybe it is? https://docs.newrelic.com/docs/plugins/plugin-developer-resources/developer-reference/metric-data-plugin-api

Maybe it's just an example? Wouldn't life be boring if they spelled out exactly how this worked? No. No it wouldn't. This is boring.

----

Edit: Which is flatly contradicted here: https://docs.newrelic.com/docs/plugins/plugin-developer-resources/developer-reference/plugin-data#metric_unit_conversions

Which has it as "kiloBytes", but perhaps it's case insensitive. Who knows? It is however 1000, not 1024 bytes.