### PR TITLE
Changed metric names to nest better and added more

### DIFF
--- a/tests/unit/viahtml/stats_test.py
+++ b/tests/unit/viahtml/stats_test.py
@@ -52,15 +52,15 @@ class TestUWSGINewRelicStatsGenerator:
             ("Custom/Alive/Metrics", 1),
             ("Custom/Alive/App", 1),
             ("Custom/System/Load", 16),
-            ("Custom/ListenQueue/Size", 12),
-            ("Custom/ListenQueue/Errors", 13),
-            ("Custom/SignalQueue/Size", 14),
+            ("Custom/Queue/Listen/Size", 12),
+            ("Custom/Queue/Listen/Errors", 13),
+            ("Custom/Queue/Signal/Size", 14),
             (
-                "Custom/Socket/Queue/Size",
+                "Custom/Queue/Socket/Size",
                 {"total": 17, "count": 1, "min": 17, "max": 17, "sum_of_squares": 289},
             ),
             (
-                "Custom/Socket/Queue/Max",
+                "Custom/Queue/Socket/Max",
                 {
                     "total": 100,
                     "count": 1,
@@ -69,6 +69,8 @@ class TestUWSGINewRelicStatsGenerator:
                     "sum_of_squares": 10000,
                 },
             ),
+            ("Custom/Worker/Count/Cheap", 6),
+            ("Custom/Worker/Count/Idle", 1),
             ("Custom/Worker/Count/Accepting", 5),
             ("Custom/Worker/Count/Max", 7),
             (
@@ -80,7 +82,7 @@ class TestUWSGINewRelicStatsGenerator:
                 {"total": 7, "count": 5, "min": 0, "max": 5, "sum_of_squares": 29},
             ),
             (
-                "Custom/Worker/Killed",
+                "Custom/Worker/Count/Killed",
                 {"total": 7, "count": 5, "min": 0, "max": 4, "sum_of_squares": 21},
             ),
             (


### PR DESCRIPTION
 * Changed "ListenQueue", "Socket/Queue" and "SignalQueue" to all be "Queue/*"
 * Moved "Worker/Killed" to "Worker/Count/Killed"
 * Added "Worker/Count/Idle" and  "Worker/Count/Cheap"

This should all facilitate adding more things to single graphs.

There are a couple of motivations for this:

 * The queues don't seem to show much, so they might as well be boring together
 * The "accepting" doesn't actually mean it's consuming any resources so the distinction between "idle" and "cheap" matters for estimating actual resource consumption
 * e.g. We show 32 workers "accepting" all the time but the memory varies wildly. This is because some "accepting" workers are "cheap"'ed and don't do anything or use any resources