### PR TITLE
Change the T3 to use more memory and the dev to use less

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -28,28 +28,28 @@ log-5xx = true
 
 max-requests = 1000                  # Restart workers after this many requests
 max-worker-lifetime = 3600           # Restart workers after this many seconds
-reload-on-rss = 256                  # Restart workers after this much resident memory (Mb)
+reload-on-rss = 128                  # Restart workers after this much resident memory (Mb)
 worker-reload-mercy = 60             # How long to wait before forcefully killing workers
 
 # Worker cheaping
 
 cheaper-algo = busyness
-processes = 32                       # Maximum number of workers allowed
-cheaper = 4                          # Minimum number of workers allowed
-cheaper-initial = 16                 # Workers created at startup
+processes = 16                       # Maximum number of workers allowed
+cheaper = 2                          # Minimum number of workers allowed
+cheaper-initial = 8                  # Workers created at startup
 cheaper-overload = 1                 # Length of a cycle in seconds
 cheaper-step = 2                     # How many workers to spawn at a time
 
 cheaper-busyness-multiplier = 30     # How many cycles to wait before killing workers
 cheaper-busyness-min = 20            # Below this threshold, kill workers (if stable for multiplier cycles)
 cheaper-busyness-max = 70            # Above this threshold, spawn new workers
-cheaper-busyness-backlog-alert = 8   # Spawn emergency workers if more than this many requests are waiting in the queue
+cheaper-busyness-backlog-alert = 4   # Spawn emergency workers if more than this many requests are waiting in the queue
 cheaper-busyness-backlog-step = 2    # How many emergency workers to create if there are too many requests in the queue
 
 # These values need to be trimmed down while running inside Via 3, but can flex
 # back up depending on the machine they are deployed on
-cheaper-rss-limit-soft = 805306368   # Don't spawn new workers if total RSS over 768Mb
-cheaper-rss-limit-hard = 1207959552  # Kill a worker if total RSS over 1152MB (t3-small has 2G)
+cheaper-rss-limit-soft = 402653184  # Don't spawn new workers if total RSS over 384Mb
+cheaper-rss-limit-hard = 536870912  # Kill a worker if total RSS over 512
 
 # Better names in logs
 

--- a/conf/uwsgi/t3_small.ini
+++ b/conf/uwsgi/t3_small.ini
@@ -28,7 +28,7 @@ log-5xx = true
 
 max-requests = 1000                  # Restart workers after this many requests
 max-worker-lifetime = 3600           # Restart workers after this many seconds
-reload-on-rss = 256                  # Restart workers after this much resident memory (Mb)
+reload-on-rss = 128                  # Restart workers after this much resident memory (Mb)
 worker-reload-mercy = 60             # How long to wait before forcefully killing workers
 
 # Worker cheaping
@@ -48,8 +48,8 @@ cheaper-busyness-backlog-step = 2    # How many emergency workers to create if t
 
 # These values need to be trimmed down while running inside Via 3, but can flex
 # back up depending on the machine they are deployed on
-cheaper-rss-limit-soft = 805306368   # Don't spawn new workers if total RSS over 768Mb
-cheaper-rss-limit-hard = 1207959552  # Kill a worker if total RSS over 1152MB (t3-small has 2G)
+cheaper-rss-limit-soft = 1342177280  # Don't spawn new workers if total RSS over 1280Mb
+cheaper-rss-limit-hard = 1610612736  # Kill a worker if total RSS over 1536MB (t3-small has 2G)
 
 # Better names in logs
 


### PR DESCRIPTION
I was initiall setting the dev settings to be the same as live, but we have
to run many services locally, and some people might not have that much RAM
to play with. It's also just not necessary locally.