### PR TITLE
Config Update - nginx.conf

### DIFF
--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -13,7 +13,7 @@ http {
     sendfile        on;
     keepalive_timeout  65;
     resolver 8.8.8.8 ipv6=off;
-    access_log /dev/stdout;
+    access_log off;
 
     # The AWS load balancer talks to the server via http so use the scheme the
     # client provided in the originating request via AWS's X-Forwarded-Proto


### PR DESCRIPTION
This branch delivers an update to `nginx.conf`. The access_log for the nginx
service running inside our Docker container has been turned off. This brings
the configuration in line with our other applications and stops us sending duplicate
information to Paperrtail.