### PR TITLE
Add the ability to use wildcards in the blocklist

### DIFF
--- a/conf/blocklist-dev.txt
+++ b/conf/blocklist-dev.txt
@@ -1,3 +1,4 @@
 example.org publisher-blocked
 example.net media-video
 bad.example.com malicious
+*.example.edu other

--- a/tests/unit/blocklist_test.py
+++ b/tests/unit/blocklist_test.py
@@ -81,7 +81,8 @@ class TestBlocklist:
             assert len(blocklist.patterns) == 1
             ((domain, found_reason),) = blocklist.patterns.items()
             assert found_reason == reason
-            assert domain.pattern == r"^.*\.example\.com$"
+            # This regex happens to be what `fnmatch.translate` spits out
+            assert domain.pattern == r"(?s:.*\.example\.com)\Z"
 
     @pytest.mark.parametrize(
         "url,expected_blocked",

--- a/viahtml/blocklist.py
+++ b/viahtml/blocklist.py
@@ -1,5 +1,6 @@
 """The abstract blocklist object."""
 
+import fnmatch
 import os
 import re
 from enum import Enum
@@ -81,8 +82,7 @@ class Blocklist:
 
         if "*" in domain:
             # Convert a string with '*' wildcards into a regex
-            pattern = "^" + re.escape(domain).replace("\\*", ".*") + "$"
-            pattern = re.compile(pattern, re.IGNORECASE)
+            pattern = re.compile(fnmatch.translate(domain), re.IGNORECASE)
             self.patterns[pattern] = reason
         else:
             self.domains[domain] = reason


### PR DESCRIPTION
 * This also added some helper functions
 * This meant the tests weren't tinking with the guts of the object any more

### Testing notes

 * Run `make dev`
 * Observe that `*.example.edu` is in `conf/blocklist-dev.txt`
 * Goto: http://localhost:9085/http://anything.example.edu
 * You should see the block page