### PR TITLE
Fix config for macos

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -12,7 +12,9 @@
 
 # Sane defaults
 
-strict = true                         # Fail for any config options uWSGI doesn't understand
+#strict = true                         # Fail for any config options uWSGI doesn't understand.
+                                       # Currently the presence of this value prevents the
+                                       # app from running in MacOS.
 master = true
 enable-threads = true
 vacuum = true                         # Delete sockets during shutdown


### PR DESCRIPTION
`strict=false` AND `strict=true` both prevent the app from running on MacOS. Remove this value temporarily until we learn why.