### PR TITLE
Add a /robots.txt file

### DIFF
--- a/tests/unit/viahtml/views/robots_test.py
+++ b/tests/unit/viahtml/views/robots_test.py
@@ -1,0 +1,33 @@
+import pytest
+from h_matchers import Any
+
+from viahtml.views.robots import RobotsView
+
+
+class TestRobotsView:
+    @pytest.mark.parametrize(
+        "path,responds",
+        (
+            ("/robots.txt", True),
+            ("/http://example.com", False),
+        ),
+    )
+    def test_it_responds_to_the_robots_txt_url(self, path, responds, start_response):
+        response = RobotsView()(path, {}, start_response)
+
+        assert bool(response) == responds
+
+    def test_it_returns_the_expected_response(self, start_response):
+        response = RobotsView()("/robots.txt", {}, start_response)
+
+        start_response.assert_called_once_with(
+            "200 OK",
+            Any.list.containing(
+                [
+                    ("Cache-Control", "public, max-age=1800"),
+                    ("Content-Type", "text/plain"),
+                ]
+            ).only(),
+        )
+
+        assert response == b"User-agent: * \nDisallow: /"

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -9,6 +9,7 @@ from werkzeug.wsgi import get_path_info
 from viahtml.hooks import Hooks
 from viahtml.patch import apply_post_app_hooks, apply_pre_app_hooks
 from viahtml.views.blocklist import BlocklistView
+from viahtml.views.robots import RobotsView
 from viahtml.views.routing import RoutingView
 from viahtml.views.status import StatusView
 
@@ -27,6 +28,7 @@ class Application:
             StatusView(),
             BlocklistView(config["checkmate_host"]),
             RoutingView(config["routing_host"]),
+            RobotsView(),
         )
 
         # Setup hook points and apply those which must be done pre-application

--- a/viahtml/views/robots.py
+++ b/viahtml/views/robots.py
@@ -1,0 +1,27 @@
+"""The robots.txt endpoint."""
+
+
+class RobotsView:
+    """robots.txt endpoint."""
+
+    def __call__(self, path, environ, start_response):
+        """Provide a robots.txt response if required.
+
+        :param path: the URL path of the request
+        :param environ: the WSGI environ dict
+        :param start_response: the WSGI start_response() function
+        :return: the response body content
+        :rtype: bytes
+        """
+        if path.rstrip("/") != "/robots.txt":
+            return None
+
+        start_response(
+            "200 OK",
+            [
+                ("Cache-Control", "public, max-age=1800"),
+                ("Content-Type", "text/plain"),
+            ],
+        )
+
+        return "User-agent: * \nDisallow: /".encode("utf-8")


### PR DESCRIPTION
Fixes https://github.com/hypothesis/checkmate/issues/85

It seems like this should just be a static file rather than Python code but I'm not sure that Via HTML has a way to serve a static plain text file at a given URL, and the Python way was easy to do. Legacy Via does seem to manage to serve a test file somehow: https://github.com/hypothesis/via/blob/master/static/robots.txt

Testing
-------

With [httpie](https://httpie.io/):

    $ http GET 'http://localhost:9085/robots.txt'
    HTTP/1.1 200 OK
    Cache-Control: public, max-age=1800
    Connection: keep-alive
    Content-Type: text/plain
    Date: Thu, 21 Jan 2021 14:57:45 GMT
    Server: nginx/1.17.6
    Transfer-Encoding: chunked
    X-NGINX-Cache-Status: MISS
    X-Via: html

    User-agent: *
    Disallow: /

Or just open http://localhost:9085/robots.txt in a browser.

You can also test that it _doesn't_ break other URLs, e.g. http://localhost:9085/_status or http://localhost:9085/proxy/http://example.com/