### PR TITLE
Tell Google not to index or follow Via HTML pages

### DIFF
--- a/tests/unit/viahtml/hooks/_headers_test.py
+++ b/tests/unit/viahtml/hooks/_headers_test.py
@@ -1,4 +1,5 @@
 import pytest
+from h_matchers import Any
 from pytest import param
 
 from viahtml.hooks._headers import Headers
@@ -68,6 +69,13 @@ class TestHeaders:
             if header[0].lower() == "cache-control"
         ]
         assert cache_control_headers == [("Cache-Control", expected)]
+
+    def test_modify_outbound_inserts_noindex_header(self, headers):
+        modified_headers = headers.modify_outbound([])
+
+        assert modified_headers == Any.list.containing(
+            [("X-Robots-Tag", "noindex, nofollow")]
+        )
 
     @pytest.fixture(
         params=(

--- a/viahtml/hooks/_headers.py
+++ b/viahtml/hooks/_headers.py
@@ -91,6 +91,8 @@ class Headers:
             ):
                 headers.append((header, value))
 
+        headers.append(("X-Robots-Tag", "noindex, nofollow"))
+
         return headers
 
     def translate_cache_control(self, value):


### PR DESCRIPTION
Add `X-Robots-Tag: noindex, nofollow` headers to all responses.

This tells Google not to index Via HTML's pages and not to follow links on those pages. See:

* https://github.com/hypothesis/checkmate/issues/166
* https://developers.google.com/search/docs/advanced/crawling/block-indexing#http-response-header
* https://developers.google.com/search/reference/robots_meta_tag#xrobotstag

Testing
-------

When you proxy a page (example: <http://localhost:9085/https://www.theguardian.com/uk>) both the root HTML response and all proxied page resource responses should have `X-Robots-Tag: noindex, nofollow` headers.

Examples:

    curl -sSL -D - http://localhost:9085/https://www.theguardian.com/uk -o /dev/null

    curl -sSL -D - http://localhost:9085/proxy/cs_/https://assets.guim.co.uk/stylesheets/ee38701f46b3fd0331ecbeae917d915a/facia.garnett.css -o /dev/null

    curl -sSL -D - http://localhost:9085/proxy/https://i.guim.co.uk/img/media/4b1d50a3d0af67ad22882a87e233607ff1ac0309/120_0_1800_1080/master/1800.jpg?width=460&quality=85&auto=format&fit=max&s=bdffa092a2023142d2c6a40d82d29076 -o /dev/null

    curl -sSL -D - ttp://localhost:9085/proxy/oe_/https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2 -o /dev/null