### PR TITLE
Revert "Bump pywb from 2.4.2 to 2.5.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,9 +28,9 @@ fakeredis==0.16.0
     # via pywb
 future==0.18.2
     # via h-checkmatelib
-gevent==20.9.0
+gevent==1.4.0
     # via pywb
-greenlet==1.0.0
+greenlet==0.4.16
     # via gevent
 h-checkmatelib==1.0.3
     # via -r requirements.in
@@ -62,7 +62,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pytz==2020.1
     # via babel
-pywb==2.5.0
+pywb==2.4.2
     # via -r requirements.in
 pyyaml==5.3.1
     # via pywb
@@ -113,10 +113,6 @@ wsgiprox==1.5.2
     # via pywb
 zipp==3.4.0
     # via importlib-metadata
-zope.event==4.5.0
-    # via gevent
-zope.interface==5.2.0
-    # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
We started seeing exceptions during the prod deployment. We're going to revert and investigate those. See https://hypothes-is.slack.com/archives/C4K6M7P5E/p1612802086014100.

The exceptions looked like this:

```
web (stderr)         | Traceback (most recent call last):
web (stderr)         |   File "/usr/local/lib/python3.6/site-packages/pywb/apps/wbrequestresponse.py", line 166, in __call__
web (stderr)         |     self.status_headers.headers)
web (stderr)         |   File "./viahtml/app.py", line 57, in proxy_start_response
web (stderr)         |     headers = self.hooks.headers.modify_outbound(headers)
web (stderr)         |   File "./viahtml/hooks/_headers.py", line 84, in modify_outbound
web (stderr)         |   File "./viahtml/hooks/_headers.py", line 114, in translate_cache_control
web (stderr)         | TypeError: '<' not supported between instances of 'str' and 'int'
web (stderr)         | 
web (stderr)         | During handling of the above exception, another exception occurred:
web (stderr)         | 
web (stderr)         | Traceback (most recent call last):
web (stderr)         |   File "./viahtml/app.py", line 62, in __call__
web (stderr)         |     return self.app(environ, proxy_start_response)
web (stderr)         |   File "/usr/local/lib/python3.6/site-packages/pywb/apps/frontendapp.py", line 571, in __call__
web (stderr)         |     return self.handler(environ, start_response)
web (stderr)         |   File "/usr/local/lib/python3.6/site-packages/pywb/apps/frontendapp.py", line 620, in handle_request
web (stderr)         |     return response(environ, start_response)
web (stderr)         |   File "/usr/local/lib/python3.6/site-packages/pywb/apps/wbrequestresponse.py", line 170, in __call__
web (stderr)         |     self.status_headers.headers)
web (stderr)         |   File "./viahtml/app.py", line 57, in proxy_start_response
web (stderr)         |     headers = self.hooks.headers.modify_outbound(headers)
web (stderr)         |   File "./viahtml/hooks/_headers.py", line 84, in modify_outbound
web (stderr)         |   File "./viahtml/hooks/_headers.py", line 114, in translate_cache_control
web (stderr)         | TypeError: '<' not supported between instances of 'str' and 'int'
```

Reverts hypothesis/viahtml#53