### PR TITLE
Fix crash when Cache-Control `max-age` is invalid

### DIFF
--- a/tests/unit/viahtml/hooks/_headers_test.py
+++ b/tests/unit/viahtml/hooks/_headers_test.py
@@ -48,8 +48,6 @@ class TestHeaders:
             ("max-age=604800", "max-age=604800"),
             ("private, max-age=0", "private, max-age=0"),
             ("private, max-age=604800", "private, max-age=604800"),
-            ("public, max-age=abc", "public, max-age=abc"),  # Invalid max-age value
-            ("public, max-age=", "public, max-age="),  # Missing max-age value
             # When the cache is public, and below cloudflare caching numbers, we
             # mark it as private only. The order changes a bit here too
             ("public, max-age=0", "max-age=0, private"),
@@ -61,6 +59,10 @@ class TestHeaders:
             ("public, max-age=604800; ignore-me", "public, max-age=604800"),
             ("public, max-age=5000.23", "public, max-age=5000"),
             ("public, max-age=10.23", "max-age=10, private"),
+            # Unparseable max-age values, treated as 0 to prevent Cloudflare
+            # from caching for a minimum of 30 minutes.
+            ("public, max-age=abc", "max-age=0, private"),
+            ("public, max-age=", "max-age=0, private"),
         ),
     )
     def test_modify_outbound_translates_cache_control_headers(

--- a/viahtml/hooks/_headers.py
+++ b/viahtml/hooks/_headers.py
@@ -120,9 +120,10 @@ class Headers:
             try:
                 parsed.max_age = int(max_age_digits)
             except ValueError:
-                # If we couldn't extract a valid `max_age` value, treat it the same
-                # as if it were missing.
-                return value
+                # If we couldn't extract a valid `max_age` value, treat it as zero
+                # to prevent downstream from caching it in case it was intended to
+                # be < CLOUDFLARE_MIN_CACHE_TIME.
+                parsed.max_age = 0
 
         if parsed.max_age < self.CLOUDFLARE_MIN_CACHE_TIME:
             parsed.public = False


### PR DESCRIPTION
The Cache-Control header should be a comma-separated list of directives and
the `max-age` directive should have an integer value [1]. Of course in the real world
that doesn't always happen and certain invalid max-age values could result in
`parsed.max_age` being a str, causing an exception when trying to compare it as an int.

In real requests I and bug reports I found examples of headers
incorrectly using `;` as a separator and (old) servers generating float
max-age values. For now we just ignore such headers.

Fixes #61

[1] https://tools.ietf.org/html/rfc7234#appendix-C