### PR TITLE
Add Referer and Sec-Fetch-Site as a way to pass auth

### DIFF
--- a/tests/unit/viahtml/context_test.py
+++ b/tests/unit/viahtml/context_test.py
@@ -6,19 +6,21 @@ from viahtml.context import Context
 
 
 class TestContext:
-    def test_get_path(self, context, environ, wsgi):
-        path = context.path
+    @pytest.mark.parametrize(
+        "prop,wsgi_method",
+        (
+            ("path", "get_path_info"),
+            ("url", "get_current_url"),
+            ("host", "get_host"),
+        ),
+    )
+    def test_pass_through_properties(
+        self, context, environ, wsgi, prop, wsgi_method
+    ):  # pylint: disable=too-many-arguments
+        value = getattr(context, prop)
 
-        # This is a straight wrapper, nothing fancy
-        assert path == wsgi.get_path_info.return_value
-        wsgi.get_path_info.assert_called_once_with(environ)
-
-    def test_url(self, context, environ, wsgi):
-        url = context.url
-
-        # This is a straight wrapper, nothing fancy
-        assert url == wsgi.get_current_url.return_value
-        wsgi.get_current_url.assert_called_once_with(environ)
+        assert value == getattr(wsgi, wsgi_method).return_value
+        getattr(wsgi, wsgi_method).assert_called_once_with(environ)
 
     @pytest.mark.parametrize(
         "path,proxied_url",

--- a/viahtml/context.py
+++ b/viahtml/context.py
@@ -47,6 +47,13 @@ class Context:
 
     @property
     @lru_cache(1)
+    def host(self):
+        """Get our own hostname."""
+
+        return wsgi.get_host(self.http_environ)
+
+    @property
+    @lru_cache(1)
     def proxied_url(self):
         """Get the proxied URL without any Via parameters."""
         url = self.proxied_url_with_config

--- a/viahtml/views/authentication.py
+++ b/viahtml/views/authentication.py
@@ -1,6 +1,7 @@
 """Token based security measures."""
 from datetime import timedelta
 from http import HTTPStatus
+from urllib.parse import urlparse
 
 from h_vialib.exceptions import MissingToken, TokenException
 from h_vialib.secure import RandomSecureNonce, TokenBasedCookie, ViaSecureURL
@@ -56,7 +57,7 @@ class AuthenticationView:
             return None
 
         try:
-            self._verify_tokens(context)
+            self._check_for_authorization(context)
 
         except TokenException as err:
             return context.make_response(
@@ -67,23 +68,51 @@ class AuthenticationView:
         # We might have added a header, but we don't want to handle the request
         return None
 
-    def _verify_tokens(self, context):
-        # Look for cookies first
+    def _check_for_authorization(self, context):
+        if self._has_valid_browsing_cookie(context):
+            return
+
+        if self._is_referred_by_us(context) or self._has_signed_url(context):
+            if not self._enable_cookie:
+                return
+
+            # Set a browsing cookie in this case
+            cookie_header, cookie_value = self._secure_cookie.create(
+                max_age=self.COOKIE_MAX_AGE
+            )
+
+            context.add_header(cookie_header, cookie_value)
+
+    @classmethod
+    def _is_referred_by_us(cls, context):
+        """Check if the referrer is ourselves."""
+
+        # This header is set by some browsers like Chrome to let you know
+        # general information about where the request came from, without
+        # directly divulging the origin URL for privacy reasons
+        sec_fetch = context.get_header("Sec-Fetch-Site")
+        if sec_fetch in ("same-origin", "same-site"):
+            return True
+
+        referrer = context.get_header("Referer")
+        if not referrer:
+            return False
+
+        try:
+            parsed_referrer = urlparse(referrer)
+        except ValueError:
+            # By rights this shouldn't be possible, as the browser shouldn't
+            # send us broken URLs, but why leave it to chance?
+
+            return False
+
+        return parsed_referrer.netloc == context.host
+
+    def _has_valid_browsing_cookie(self, context):
         try:
             return self._secure_cookie.verify(context.get_header("Cookie"))
         except MissingToken:
-            pass
+            return False
 
-        # Looks like there's no cookie, so try the path
-        self._secure_url.verify(context.url)
-
-        if not self._enable_cookie:
-            return None
-
-        # Looks like we do have a signed URL, so add a cookie for future
-        # surfing
-        cookie_header, cookie_value = self._secure_cookie.create(
-            max_age=self.COOKIE_MAX_AGE
-        )
-
-        return context.add_header(cookie_header, cookie_value)
+    def _has_signed_url(self, context):
+        return self._secure_url.verify(context.url)


### PR DESCRIPTION
The current cascade of possibilities is now:

* Auth is disabled - let everything through
* You have a cookie - let you through
* The following things let you through, and set the above cookie:
    * You have `Sec-Fetch-Site` either `same-site` or `same-origin` 
    * You have a referrer which is us
    * You have a signed URL
* Block