### PR TITLE
Include all of the javascript content from pywb

### DIFF
--- a/bin/build_static.py
+++ b/bin/build_static.py
@@ -6,7 +6,35 @@ from shutil import copyfile, rmtree
 from pkg_resources import resource_filename
 
 # All the pywb resources we know we need
-MANIFEST = ("wombat.js",)
+MANIFEST = (
+    "autoFetchWorker.js",
+    "autoFetchWorkerProxyMode.js",
+    "default_banner.js",
+    "flowplayer/toolbox.flashembed.js",
+    "js/bootstrap.min.js",
+    "js/jquery-latest.min.js",
+    "js/url-polyfill.min.js",
+    "query.js",
+    "queryWorker.js",
+    "search.js",
+    "transclusions.js",
+    "vidrw.js",
+    "wb_frame.js",
+    "wombat.js",
+    "wombatProxyMode.js",
+    "wombatWorkers.js",
+    "ww_rw.js",
+)
+
+
+def _copy(source_file, target_file):
+    print(f"{source_file} >>> {target_file}")
+
+    dir_name = os.path.dirname(target_file)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+
+    copyfile(source_file, target_file)
 
 
 def _create_static(source, target):
@@ -14,15 +42,12 @@ def _create_static(source, target):
         print(f"Removing old static directory: {target}")
         rmtree(target)
 
-    os.makedirs(target)
-
     print(f"Copying `pywb` static content: {source}")
     for path in MANIFEST:
         source_file, target_file = os.path.join(source, path), os.path.join(
             target, path
         )
-        print(f"{source_file} >>> {target_file}")
-        copyfile(source_file, target_file)
+        _copy(source_file, target_file)
 
     print(f"Created: {target}")
 

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
         # This is for dev only
         include viahtml/ssl_config.conf;
 
-        location /static/ {
+        location ~ ^/static/(.*)$ {
             sendfile            on;
             sendfile_max_chunk  1m;
             tcp_nopush          on;
@@ -54,13 +54,12 @@ http {
 
             add_header "Cache-Control" "private, max-age=3600, stale-while-revalidate=36000";
 
-            alias /var/lib/hypothesis/static/static/;
+            root /var/lib/hypothesis/static/static;
 
-            location /static/wombat.js {
-                # This is a bit gross, but `pywb` very much wants /static all to
-                # itself, so we have to work around it
-                try_files /pywb/wombat.js =404;
-            }
+            # This is a bit gross, but `pywb` very much wants /static all to
+            # itself, so we have to work around it. This tries for a match in
+            # the /pywb directory first, and then in the root after
+            try_files /pywb/$1 /$1 =404;
         }
 
         location /http {

--- a/tox.ini
+++ b/tox.ini
@@ -51,15 +51,13 @@ passenv =
 deps =
     dev: -r requirements-dev.in
     tests: coverage
-    {tests,lint}: -r requirements.txt
+    {tests,lint,build}: -r requirements.txt
     {tests,lint}: -r requirements-test.in
     lint: pylint<2.5
     lint: pydocstyle
     {format,checkformatting}: black
     {format,checkformatting}: isort
     pip-compile: pip-tools<5
-    build: pywb
-    build: whitenoise
 whitelist_externals =
     dev: gunicorn
     dev: newrelic-admin


### PR DESCRIPTION
It's not clear how much of this is required, but it's more than just the `wombat.js` file. So lets err on the side of caution and add
them all. This was specifically prompted by sites which triggered 'wombatWorkers.js` being missing.

This was spotted on https://www.vice.com/en_us/article/5dmpbz/how-elf-on-the-shelf-became-a-surveillance-state-apparatus, you could see lots of `wombatWorkers.js` failing.

Some of the resources that are missing are actually as a result of `pywb` error pages which load bootstrap etc.

## Testing notes

* Run `make build`
* You should see lots of things put into `static/static/pywb`
* You should be able to access regular static items: 
  * http://localhost:9085/static/img/favicon.ico
* You should be able to access `pywb` items without the `pywb/` directory name:
  * http://localhost:9085/static/wombat.js
  * http://localhost:9085/static/wombatWorkers.js
