### PR TITLE
Fix context header translation

### DIFF
--- a/tests/unit/viahtml/context_test.py
+++ b/tests/unit/viahtml/context_test.py
@@ -119,7 +119,7 @@ class TestContext:
         assert context.headers == [("X-Foo", "Foo")]
 
     def test_get_header_reads_from_environ(self, context, environ):
-        environ["HTTP_XFOO"] = "Foo!"
+        environ["HTTP_X_FOO"] = "Foo!"
 
         value = context.get_header("X-Foo")
 
@@ -130,7 +130,7 @@ class TestContext:
         # Noise must come first to get coverage
         context.add_header("X-Noise", "Noo")
         context.add_header(header_name, "Foo!")
-        environ["HTTP_XFOO"] = "Noo"
+        environ["HTTP_X_FOO"] = "Noo"
 
         value = context.get_header("X-Foo")
 

--- a/viahtml/context.py
+++ b/viahtml/context.py
@@ -124,8 +124,7 @@ class Context:
         """
         for key, value in self.headers:
             if key.lower() == name.lower():
-                return value  #
+                return value
 
-        # https://tools.ietf.org/html/rfc3875#section-4.1.18
-        cgi_name = "HTTP_" + name.upper().replace("-", "")
-        return self.http_environ.get(cgi_name)
+        wsgi_name = "HTTP_" + name.upper().replace("-", "_")
+        return self.http_environ.get(wsgi_name)


### PR DESCRIPTION
WSGI does not follow CGI standards. The standard for CGI is to translate headers into the environment dict like this:

* `A-Header-Name` -> `HTTP_AHEADERNAME`

WSGI does it like this:

* `A-Header-Name` -> `HTTP_A_HEADER_NAME`

This means our `get_header` method can only get headers without dashes without this PR.