### PR TITLE
Refactor tests to have default deny and use a headers/context fixture

### DIFF
--- a/tests/unit/viahtml/views/authentication_test.py
+++ b/tests/unit/viahtml/views/authentication_test.py
@@ -26,27 +26,21 @@ class TestAuthenticationView:
         )
         RandomSecureNonce.assert_called_once_with("not_a_secret")
 
-    def test_it_reads_a_signed_path_with_no_cookie(
+    def test_it_allows_through_a_signed_path(
         self, view, context, TokenBasedCookie, ViaSecureURL
     ):
-        TokenBasedCookie.return_value.verify.side_effect = MissingToken
         context.url = "http://via/proxy/http://example.com?via.sec=A_GOOD_TOKEN"
+        ViaSecureURL.return_value.verify.side_effect = None
 
         result = view(context)
 
         assert result is None
         ViaSecureURL.return_value.verify.assert_called_once_with(context.url)
-        secure_cookie = TokenBasedCookie.return_value
-        secure_cookie.create.assert_called_once_with(
-            max_age=AuthenticationView.COOKIE_MAX_AGE
-        )
-        context.add_header.assert_called_once_with(*secure_cookie.create.return_value)
 
-    def test_it_blocks_if_the_path_is_signed_badly(
-        self, view, context, ViaSecureURL, TokenBasedCookie
-    ):
+        self.assert_browser_cookie_set(TokenBasedCookie, context)
+
+    def test_it_blocks_if_the_path_is_signed_badly(self, view, context, ViaSecureURL):
         context.url = "http://via/proxy/http://example.com?via.sec=A_BAD_TOKEN"
-        TokenBasedCookie.return_value.verify.side_effect = MissingToken
         ViaSecureURL.return_value.verify.side_effect = InvalidToken("bad")
 
         result = view(context)
@@ -54,23 +48,24 @@ class TestAuthenticationView:
         self.assert_is_unauthorized_response(result, context)
 
     def test_it_allows_through_a_request_with_cookie(
-        self, view, context, TokenBasedCookie
+        self, view, context, TokenBasedCookie, headers
     ):
+        headers["Cookie"] = "A_GOOD_COOKIE"
         context.url = "http://via/proxy/http://example.com"
-        context.get_header.return_value = "A_GOOD_COOKIE"
+        TokenBasedCookie.return_value.verify.side_effect = None
 
         result = view(context)
 
         assert result is None
 
         context.get_header.assert_called_once_with("Cookie")
-        TokenBasedCookie.return_value.verify.assert_called_once_with(
-            context.get_header.return_value
-        )
+        TokenBasedCookie.return_value.verify.assert_called_once_with(headers["Cookie"])
 
-    def test_it_blocks_if_the_cookie_is_bad(self, view, context, TokenBasedCookie):
+    def test_it_blocks_if_the_cookie_is_bad(
+        self, view, context, TokenBasedCookie, headers
+    ):
+        headers["Cookie"] = "A_BAD_COOKIE"
         context.url = "http://via/proxy/http://example.com"
-        context.get_header.return_value = "A_BAD_COOKIE"
         TokenBasedCookie.return_value.verify.side_effect = InvalidToken("bad")
 
         result = view(context)
@@ -81,29 +76,40 @@ class TestAuthenticationView:
         self, context, ViaSecureURL, TokenBasedCookie
     ):
         context.url = "http://via/proxy/http://example.com"
-        context.get_header.return_value = None
-        ViaSecureURL.return_value.verify.side_effect = MissingToken("gone")
-        TokenBasedCookie.return_value.verify.side_effect = MissingToken("gone")
 
         result = AuthenticationView(secret="not_a_secret", required=False)(context)
 
         assert result is None
 
-    def test_it_does_not_set_cookies_with_cookies_disabled(
-        self, context, TokenBasedCookie
-    ):
-        TokenBasedCookie.return_value.verify.side_effect = MissingToken
+    def test_it_does_not_set_cookies_with_cookies_disabled(self, context, ViaSecureURL):
         context.url = "http://via/proxy/http://example.com?via.sec=A_GOOD_TOKEN"
+        ViaSecureURL.return_value.verify.side_effect = None
 
         AuthenticationView(secret="not_a_secret", enable_cookie=False)(context)
 
         context.add_header.assert_not_called()
+
+    def assert_browser_cookie_set(self, TokenBasedCookie, context):
+        secure_cookie = TokenBasedCookie.return_value
+        secure_cookie.create.assert_called_once_with(
+            max_age=AuthenticationView.COOKIE_MAX_AGE
+        )
+        context.add_header.assert_called_once_with(*secure_cookie.create.return_value)
 
     def assert_is_unauthorized_response(self, result, context):
         assert result is context.make_response.return_value
         context.make_response.assert_called_once_with(
             HTTPStatus.UNAUTHORIZED, lines=[Any.string.containing("401")]
         )
+
+    @pytest.fixture
+    def headers(self):
+        return {"Referer": None, "Cookie": None}
+
+    @pytest.fixture(autouse=True)
+    def context(self, context, headers):
+        context.get_header.side_effect = headers.get
+        return context
 
     @pytest.fixture
     def view(self):
@@ -116,12 +122,16 @@ class TestAuthenticationView:
             "Set-Cookie",
             "some cookie value",
         )
+        TokenBasedCookie.return_value.verify.side_effect = MissingToken
 
         return TokenBasedCookie
 
     @pytest.fixture(autouse=True)
     def ViaSecureURL(self, patch):
-        return patch("viahtml.views.authentication.ViaSecureURL")
+        ViaSecureURL = patch("viahtml.views.authentication.ViaSecureURL")
+
+        ViaSecureURL.return_value.verify.side_effect = MissingToken
+        return ViaSecureURL
 
     @pytest.fixture(autouse=True)
     def RandomSecureNonce(self, patch):


### PR DESCRIPTION
Instead of configuring the token and cookie in every test, we'll set the various checkers to return `MissingToken` by default. Also as we can mock the context object, we can more directly express what's going on with the headers by having an explicit headers fixture.

This is going to make writing tests involving multiple ways in which we can bypass authentication easier. As otherwise we have to disable every mechanism we don't want in every test, rather than just enabling the one we do.

This is here as it was snipped out of a follow on PR which adds lots of different ways of getting through the auth, like Referer etc, which was starting to make this approach ridiculous.