### PR TITLE
Make sure our auth error page is HTML and prevent favicon requests

### DIFF
--- a/tests/unit/viahtml/views/authentication_test.py
+++ b/tests/unit/viahtml/views/authentication_test.py
@@ -136,7 +136,9 @@ class TestAuthenticationView:
     def assert_is_unauthorized_response(self, result, context):
         assert result is context.make_response.return_value
         context.make_response.assert_called_once_with(
-            HTTPStatus.UNAUTHORIZED, lines=[Any.string.containing("401")]
+            HTTPStatus.UNAUTHORIZED,
+            lines=[Any.string.containing("401")],
+            headers={"Content-Type": "text/html; charset=utf-8"},
         )
 
     @pytest.fixture

--- a/viahtml/views/authentication.py
+++ b/viahtml/views/authentication.py
@@ -62,7 +62,8 @@ class AuthenticationView:
         except TokenException as err:
             return context.make_response(
                 HTTPStatus.UNAUTHORIZED,
-                lines=[f"<h1>401 Unauthorized</h1><p>{err}</p>"],
+                lines=[self._error_template(err)],
+                headers={"Content-Type": "text/html; charset=utf-8"},
             )
 
         # We might have added a header, but we don't want to handle the request
@@ -116,3 +117,21 @@ class AuthenticationView:
 
     def _has_signed_url(self, context):
         return self._secure_url.verify(context.url)
+
+    @classmethod
+    def _error_template(cls, exception):
+        # We add a fake favicon here, to prevent the browser from requesting
+        # one, as this can trigger `pywb` to issue a redirect which effectively
+        # logs the user in by setting a `via.sec` cookie in the response.
+
+        return f"""
+        <html>
+            <head>
+                <link rel="icon" href="data:,">
+            </head>
+            <body>
+                <h1>401 Unauthorized</h1>
+                <p>{exception}</p>
+            </body>
+        </html>
+        """


### PR DESCRIPTION
This prevents a stupid work around where getting the favicon would effectively log you in. This would allow you to get around the block by refreshing the page.

This also ensures our page is understood as HTML and doesn't trigger any weird browser behavior, such as trying to download it.

This addresses:

 * https://github.com/hypothesis/viahtml/issues/77
 * https://github.com/hypothesis/viahtml/issues/78
 