### PR TITLE
Add an in app config option to turn on or off a-href rewriting

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -43,6 +43,7 @@ def upstream_website():
        </head>
        <body>
          <!-- upstream content -->
+         <a href="http://example.com">link</a>
        </body>
      </html>
      """

--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -32,6 +32,9 @@ class TestProxy:
 
         assert policy == "*MISSING*"
 
+    def test_we_dont_rewrite_links_by_default(self, app, proxied_content):
+        assert '<a href="http://example.com">link</a>' in proxied_content
+
     @pytest.mark.parametrize(
         "link_mode,expected",
         (

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -27,6 +27,7 @@ class Application:
 
         config = self._config_from_env()
 
+        self._config = config
         self._setup_logging(config["debug"])
         self.hooks = Hooks(config)
 
@@ -54,6 +55,7 @@ class Application:
         """Handle WSGI requests."""
 
         context = Context(http_environ=environ, start_response=start_response)
+        self.hooks.set_context(context)
 
         for view in self.views:
             response = view(context)
@@ -100,6 +102,12 @@ class Application:
             "checkmate_host": os.environ["CHECKMATE_URL"],
             "http_mode": asbool(os.environ.get("VIA_HTTP_MODE", False)),
             "checkmate_api_key": os.environ["CHECKMATE_API_KEY"],
+            # Rewriting related options
+            "rewrite": {
+                # Enable rewriting HTML links in the page so they lead back to
+                # Via instead of the original site
+                "a_href": False
+            },
         }
 
     @classmethod


### PR DESCRIPTION
This allows us to disable navigation from page to page inside ViaHTML. This is configurable, but only inside the app, there's no flag for it yet, as I think we always want it off now.

* Before: when you visited a page `a` links in it pointed back to Pywb
* Now: `a` links should point to the original site

This doesn't try and solve any fancy effects from Javascript etc.

This is something we want as it prevents any breakage from a lack of URL signature when people pop out of an LMS context, but we also want it because:

 * It's how support want it to work anyway (https://github.com/hypothesis/support/issues/133)
 * This also cuts down on general browsing inside Via, which we don't want to encourage (https://github.com/hypothesis/checkmate/issues/65)
 
 