### PR TITLE
Attempt to persist Via config over redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ greenlet==1.0.0
     # via gevent
 h-checkmatelib==1.0.5
     # via -r requirements.in
-h-vialib==1.0.10
+h-vialib==1.0.11
     # via -r requirements.in
 idna==2.10
     # via

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -67,6 +67,15 @@ class Hooks:
             location = response.status_headers.get_header("Location")
             if location:
                 location = self.context.make_absolute(location)
+
+                via_params, client_params = Configuration.extract_from_url(
+                    location, add_defaults=False
+                )
+                if via_params or client_params:
+                    location = Configuration.add_to_url(
+                        location, via_params, client_params
+                    )
+
                 location = self._secure_url.create(location)
                 response.status_headers.replace_header("Location", location)
 


### PR DESCRIPTION
For: https://github.com/hypothesis/viahtml/issues/83

An example URL that does this: http://xroads.virginia.edu/~drbr/wf_rose.html

Testing notes:

* Using the test harness try and `master` try and view the above link (open in a new tab)
* You should see the URL has a `via.sec` but no other options
* Checkout this branch and repeat: you should see the defaults coming through

This might be more obvious with `curl` or another tool.

Requires: https://github.com/hypothesis/h-vialib/pull/19