### PR TITLE
Read the Via params from the environment, not the location URL

### DIFF
--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -90,12 +90,11 @@ class TestHooks:
         )
 
     def test_modify_render_response_preserves_via_params_on_redirect(
-        self, hooks, wb_response
+        self, hooks, wb_response, context
     ):
+        context.http_environ = {"QUERY_STRING": "via.option=foo"}
         wb_response.status_headers.statusline = "307 Temporary Redirect"
-        wb_response.status_headers.add_header(
-            "Location", "http://example.com?via.option=foo"
-        )
+        wb_response.status_headers.add_header("Location", "http://example.com")
 
         response = hooks.modify_render_response(wb_response)
 

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -68,9 +68,10 @@ class Hooks:
             if location:
                 location = self.context.make_absolute(location)
 
-                via_params, client_params = Configuration.extract_from_url(
-                    location, add_defaults=False
+                via_params, client_params = Configuration.extract_from_wsgi_environment(
+                    self.context.http_environ, add_defaults=False
                 )
+                print("REIIRIDDD", via_params, client_params)
                 if via_params or client_params:
                     location = Configuration.add_to_url(
                         location, via_params, client_params


### PR DESCRIPTION
The location we get sent to doesn't have them on it. 

Fix for: https://github.com/hypothesis/viahtml/pull/84