### PR TITLE
Allow requests from an allow-list of referrers

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -91,6 +91,7 @@ py-tracebacker = /tmp/via-traceback-
 # stats-no-cores=true
 
 # Via config
+env = VIA_ALLOWED_REFERRERS=localhost:8001
 env = VIA_H_EMBED_URL=http://localhost:3001/hypothesis
 env = VIA_IGNORE_PREFIXES=http://localhost:5000/,http://localhost:3001/,https://localhost:5000/,https://localhost:3001/
 env = VIA_DEBUG=1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 def environment_variables():
     return {
+        "VIA_ALLOWED_REFERRERS": ",".join(
+            [
+                "localhost:8001",
+            ]
+        ),
         "VIA_H_EMBED_URL": "http://localhost:3001/hypothesis",
         "VIA_IGNORE_PREFIXES": ",".join(
             [

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -38,6 +38,7 @@ class Application:
                 required=not config["disable_authentication"],
                 enable_cookie=not config["disable_cookie"],
                 http_mode=config["http_mode"],
+                allowed_referrers=config["allowed_referrers"],
             ),
             BlocklistView(config["checkmate_host"], config["checkmate_api_key"]),
             RoutingView(config["routing_host"]),
@@ -90,6 +91,9 @@ class Application:
         """Parse options from environment variables."""
 
         return {
+            "allowed_referrers": cls._split_multiline(
+                os.environ.get("VIA_ALLOWED_REFERRERS", "")
+            ),
             "ignore_prefixes": cls._split_multiline(os.environ["VIA_IGNORE_PREFIXES"]),
             "h_embed_url": os.environ["VIA_H_EMBED_URL"],
             "debug": os.environ.get("VIA_DEBUG", False),


### PR DESCRIPTION
Add a new mechanism for allowing requests which is based upon an
allow-list of referrers, configured via a `VIA_ALLOWED_REFERRERS`
environment variable which contains a comma-separated list of domains (eg. "lms.hypothes.is, otherservice.hypothes.is") [2]

This is intended to be used to allow requests coming from the LMS
application and potentially other Hypothesis services, as an alternative
to signed URLs. Providing that the `Referer` header is sent by all (or
at least, close enough to all) browsers and is sent in the contexts we
care about, this might provide a simpler alternative.

In the process the `Sec-Fetch-Site` check has been changed from allowing
`same-site` and `same-origin` to `same-origin` only. Allowing
`same-site` permits requests from any service on the same _registrable
domain_ [1]. This means that if there is a single service somewhere on the
domain that allows user-defined links, a user can create links that will
proxy an arbitrary URL through Via. Restricting the `Sec-Fetch-Site`
check to `same-origin` only means it is the same as checking if the
request's `Referer` is the current origin.

[1] A _registrable domain_ is the "public suffix" of a domain plus one part. eg. in "via.hypothes.is" the public suffix is ".is" and the registrable domain is "hypothes.is". See https://publicsuffix.org/list/.
[2] The list is comma-separated because it is parsed using the same code as the existing VIA_IGNORE_PREFIXES variable. This is different to the Pyramid `aslist` parsing that is used in other apps. Not sure if that was intentional.

This issue is part of a response to https://github.com/hypothesis/support/issues/174.

----

**Testing:**

To test the change in this PR directly without the LMS:

1. Save the following file as `index.html`
    ```html
   <html><body>Go to <a href="http://localhost:9085/proxy/https://example.com">viahtml</a></body></html>
    ```
2. Run `python -m http.server 6005` in the dir where `index.html` was saved
3. Open http://localhost:6005 in a browser and click the link. viahtml should block the request.
4. Modify `conf/development.ini` and change the `VIA_ALLOWED_REFERRERS` pattern to add `localhost:6005` as an allowed referrer: `env = VIA_ALLOWED_REFERRERS=localhost:8001,localhost:6005`
5. Restart the viahtml dev server and repeat step 3. This time viahtml should allow the request through.

The default configuration for `VIA_ALLOWED_REFERRERS` allows requests from the LMS host, so an integration test with the LMS can be done as follows:

1. Change the `VIA_SECRET` value in `tox.ini` to a dummy value (eg. `wrong_secret`) so that requests from the LMS will not be allowed if they rely on the signed URL
2. Create an HTML assignment in the LMS using the local dev server and check that it loads in Chrome and Firefox

A variation on the above is to pick a URL which redirects. For example, pick a Wikipedia URL and lower-case the article title in the URL. It will redirect to the canonical-cased article title.