### PR TITLE
Check URL signature against the exact URL from the HTTP request line

### DIFF
--- a/tests/unit/viahtml/context_test.py
+++ b/tests/unit/viahtml/context_test.py
@@ -10,7 +10,6 @@ class TestContext:
         "prop,wsgi_method",
         (
             ("path", "get_path_info"),
-            ("url", "get_current_url"),
             ("host", "get_host"),
         ),
     )
@@ -167,6 +166,27 @@ class TestContext:
 
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "request_uri,expected",
+        [
+            ("/proxy/http://example.com", "http://via/proxy/http://example.com"),
+            ("/proxy/http://example.com/", "http://via/proxy/http://example.com/"),
+            ("/proxy/http://example.com/?", "http://via/proxy/http://example.com/?"),
+            (
+                "/proxy/http://en.wikipedia.org/Bob (singer)",
+                "http://via/proxy/http://en.wikipedia.org/Bob (singer)",
+            ),
+        ],
+    )
+    def test_url_returns_exact_url_from_request(
+        self, environ, context, request_uri, expected
+    ):
+        environ["REQUEST_URI"] = request_uri
+
+        result = context.url
+
+        assert result == expected
+
     @pytest.fixture
     def environ(self):
         return {
@@ -175,6 +195,7 @@ class TestContext:
             "SERVER_PORT": "9999",
             "SCRIPT_NAME": "script",
             "PATH_INFO": "/",
+            "REQUEST_URI": "/",
         }
 
     @pytest.fixture

--- a/viahtml/context.py
+++ b/viahtml/context.py
@@ -44,7 +44,14 @@ class Context:
     def url(self):
         """Get the full request URL made to the app (with query params)."""
 
-        return wsgi.get_current_url(self.http_environ)
+        # The URL origin is obtained using `get_current_url` but the path and
+        # query string are obtained directly from `REQUEST_URI` to ensure that
+        # the returned URL exactly matches what was passed to the service. This
+        # is important if the URL contains a signature that needs to be
+        # validated.
+        root_url = wsgi.get_current_url(self.http_environ, root_only=True).rstrip("/")
+        request_uri = self.http_environ.get("REQUEST_URI", "/")
+        return root_url + request_uri
 
     @property
     @lru_cache(1)


### PR DESCRIPTION
When checking the URL signature in the `via.sec` query param it is
important that the checked request URL exactly matches the URL that was used to
sign the request. The `wsgi.get_current_url` helper normalizes the URL
information in the HTTP environ, which can result in the checked URL
being different than what was originally signed.

One way to resolve this would be to specify that some URL normalization
must be applied before the URL signature is generated to ensure that
functions such as `wsgi.get_current_url` don't return something
different than what was signed. The approach taken here however is to try to
reconstruct the original URL more faithfully by using the `REQUEST_URI`
info in the HTTP environ. This has the advantage that it is a change
that only needs to happen in this service and we don't have to enumerate
all the ways that `get_current_url` might not faithfully reconstruct the
original signed URL. This approach could still break however if the URL
gets mangled by one of the parties in between the service that generated
the signed URL and viahtml (eg. the browser).

Fixes https://github.com/hypothesis/support/issues/174