### PR TITLE
Disable redirect signing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Environment variables:
 | `VIA_SECRET`          | Secret used for checking signed URLs      | `a_very_long_random_string` |
 | `VIA_DISABLE_AUTHENTICATION` | Disable auth for dev purposes      | `false` |
 | `VIA_DISABLE_COOKIE` | Disable persistent auth sessions           | `false` |
+| `VIA_ENABLE_REDIRECT_SIGNING` | Enable signing of proxied redirect locations | `false` |
 | `VIA_HTTP_MODE` | Enabled HTTP (rather than HTTPS) mode for dev   | `false` |
 
 

--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -85,6 +85,30 @@ class TestHooks:
 
         location = response.status_headers.get_header("Location")
         hooks.context.make_absolute.assert_called_once_with(original_location)
+        assert location == "http://via/proxy/http://example.com"
+
+    @pytest.mark.parametrize(
+        "status_line",
+        (
+            "301 Moved Permanently",
+            "302 Found",
+            "303 See Other",
+            "305 Use Proxy",
+            "307 Temporary Redirect",
+            "308 Permanent Redirect",
+        ),
+    )
+    def test_modify_render_signs_redirects_if_enabled(
+        self, hooks, wb_response, status_line
+    ):
+        hooks.config["enable_redirect_signing"] = True
+        wb_response.status_headers.statusline = status_line
+        original_location = "http://via/proxy/http://example.com"
+        wb_response.status_headers.add_header("Location", original_location)
+
+        response = hooks.modify_render_response(wb_response)
+
+        location = response.status_headers.get_header("Location")
         assert location == Any.url.matching(original_location).containing_query(
             {"via.sec": Any.string()}
         )
@@ -173,6 +197,7 @@ class TestHooks:
                 "ignore_prefixes": sentinel.prefixes,
                 "secret": "not_a_secret",
                 "rewrite": {"a_href": True},
+                "enable_redirect_signing": False,
             }
         )
 

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -103,6 +103,9 @@ class Application:
                 os.environ.get("VIA_DISABLE_AUTHENTICATION", False)
             ),
             "disable_cookie": asbool(os.environ.get("VIA_DISABLE_COOKIE", False)),
+            "enable_redirect_signing": asbool(
+                os.environ.get("VIA_ENABLE_REDIRECT_SIGNING", False)
+            ),
             "checkmate_host": os.environ["CHECKMATE_URL"],
             "http_mode": asbool(os.environ.get("VIA_HTTP_MODE", False)),
             "checkmate_api_key": os.environ["CHECKMATE_API_KEY"],

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -77,7 +77,9 @@ class Hooks:
                         location, via_params, client_params
                     )
 
-                location = self._secure_url.create(location)
+                if self.config["enable_redirect_signing"]:
+                    location = self._secure_url.create(location)
+
                 response.status_headers.replace_header("Location", location)
 
         return response


### PR DESCRIPTION
Redirect signing is no longer needed now that we overwrite `Referrer-Policy` headers, preventing third-party redirect responses from blocking the `Referer` header.

The redirect signing can be re-enabled with `VIA_ENABLE_REDIRECT_SIGNING=1` but if running with it disabled works out we'll remove the redirect signing and URL signature-based auth entirely.