### PR TITLE
Revert "Ensure Vary headers always contain `Referer` and `Sec-Fetch-Site`"

### DIFF
--- a/tests/unit/viahtml/hooks/_headers_test.py
+++ b/tests/unit/viahtml/hooks/_headers_test.py
@@ -93,35 +93,6 @@ class TestHeaders:
             [("X-Robots-Tag", "noindex, nofollow")]
         )
 
-    @pytest.mark.parametrize(
-        "upstream_headers,expected",
-        (
-            ([], "referer, sec-fetch-site"),
-            ([("Vary", "sec-fetch-site")], "referer, sec-fetch-site"),
-            ([("Vary", "Sec-Fetch-Site")], "referer, sec-fetch-site"),
-            ([("Noise", "Upstream-Value")], "referer, sec-fetch-site"),
-            (
-                [("Vary", "Upstream-Value, Upstream-Value-2")],
-                "referer, sec-fetch-site, upstream-value, upstream-value-2",
-            ),
-            (
-                [
-                    ("Vary", "Upstream-Value"),
-                    ("Vary", "Upstream-Value-2"),
-                ],
-                "referer, sec-fetch-site, upstream-value, upstream-value-2",
-            ),
-        ),
-    )
-    def test_modify_outbound_converts_vary_headers(
-        self, headers, upstream_headers, expected
-    ):
-        modified_headers = headers.modify_outbound(upstream_headers)
-
-        values = [value for (key, value) in modified_headers if key == "Vary"]
-
-        assert values == [expected]
-
     @pytest.fixture(
         params=(
             param(lambda v: v, id="mixed case"),

--- a/viahtml/hooks/_headers.py
+++ b/viahtml/hooks/_headers.py
@@ -86,19 +86,11 @@ class Headers:
         :return: Modified key-value pairs
         """
         headers = []
-        vary_types = set()
 
         for header, value in header_items:
             header_lower = header.lower()
             if header_lower == "x-archive-orig-cache-control":
                 headers.append(("Cache-Control", self.translate_cache_control(value)))
-
-            elif header_lower == "vary":
-                # Strip out any Vary headers, but keep the values
-                vary_types.update(
-                    [vary_type.strip().lower() for vary_type in value.split(",")]
-                )
-                continue
 
             if (
                 # Skip any of the many, many headers `pywb` emits
@@ -107,12 +99,6 @@ class Headers:
                 and header_lower not in self._bad_outbound_lower
             ):
                 headers.append((header, value))
-
-        # Ensure our caching is sharded by Referer and Sec-Fetch-Site, as we
-        # use these values to check sites are proxied by us. This prevents
-        # poisoning the cache by passing the referrer using `curl` for example
-        vary_types |= {"referer", "sec-fetch-site"}
-        headers.append(("Vary", ", ".join(sorted(vary_types))))
 
         # Add our own Referrer-Policy telling browsers to send us Referer headers.
         #


### PR DESCRIPTION
Reverts hypothesis/viahtml#106

According to this: https://support.cloudflare.com/hc/en-us/articles/115003206852 Cloudflare does not respect Vary headers, therefore this isn't doing anything useful for us and should go.

We'll need another solution to: https://github.com/hypothesis/checkmate/issues/215