### PR TITLE
Jenkinsfile - Introduce parallel build support for production.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,9 +62,17 @@ onlyOnMaster {
 
     milestone()
     stage("Deploy (prod)") {
-        input(message: "Deploy to prod?")
-        milestone()
-        deployApp(image: img, app: "viahtml", env: "prod3")
+	lock("prod deploy") {
+	    parallel(
+	        prod: {
+		    sleep 2
+		    deployApp(image: img, app: "viahtml", env: "prod")
+		},
+		prod3: {
+		    deployApp(image: img, app: "viahtml", env: "prod3")
+		}
+	    )
+	}
     }
 }
 


### PR DESCRIPTION
This is the final stage of updates for the ViaHTML Jenkinsfile. Support for parallel production builds has been introduced.

To summarize all the recent updates made during the course of working [Update Jenkins pipelines for Via3 and ViaHTML](https://github.com/hypothesis/playbook/issues/614)

1. Stage names have been renamed or updated. We now have...
```
* Build
* Tests
* Release
* Deploy (qa)
* Approval
* Deploy (prod)
```

2. The `Deploy (qa)` stage has been modified to perform parallel builds of two environments at the same time.
3. A dedicated `Approval` stage has been introduced to make it more obvious that someone needs to approve before proceeding to the next stage.
4. The `Deploy (prod)` stage has been modified to perform parallel builds of two environments at the same time.