### PR TITLE
Initialize New Relic manually

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -12,7 +12,7 @@ stopsignal = INT
 stopasgroup = true
 
 [program:web]
-command=newrelic-admin run-program uwsgi conf/development.ini
+command=uwsgi conf/development.ini
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:web]
-command=newrelic-admin run-program uwsgi /var/lib/hypothesis/conf/production.ini
+command=uwsgi /var/lib/hypothesis/conf/production.ini
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/viahtml/wsgi.py
+++ b/viahtml/wsgi.py
@@ -1,6 +1,10 @@
 """The application providing a WSGI entry-point."""
 import os
 
+import newrelic.agent
+
+newrelic.agent.initialize("conf/newrelic.ini")
+
 # Our job here is to leave this `application` attribute laying around as
 # it's what uWSGI expects to find.
 from viahtml.app import Application
@@ -16,3 +20,5 @@ if os.environ.get("SENTRY_DSN"):  # pragma: no cover
     # pylint: disable=redefined-variable-type
     sentry_sdk.init(dsn=os.environ["SENTRY_DSN"])
     application = SentryWsgiMiddleware(application)
+
+application = newrelic.agent.WSGIApplicationWrapper(application)


### PR DESCRIPTION
This is the only way I can get [recording custom metrics](https://github.com/hypothesis/viahtml/pull/135/) to work. Every other way I tried calling `record_custom_metric()` results in this error:

> record_custom_metric has been called but no transaction was running. As a result, the following metric has not been recorded. ... To correct this problem, supply an application object as a parameter to this record_custom_metrics call.

Even manually supplying a New Relic application object to `record_custom_metric()` as it says to, still produces the same error.

For docs on this way of configuring New Relic see:

https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration/