### PR TITLE
Add New Relic Checkmate failed requests metric

### DIFF
--- a/viahtml/views/blocklist.py
+++ b/viahtml/views/blocklist.py
@@ -32,6 +32,9 @@ class BlocklistView:
             )
         except CheckmateException:
             blocked = None
+            newrelic.agent.record_custom_metric("Custom/Checkmate/Failed_requests", 1)
+        else:
+            newrelic.agent.record_custom_metric("Custom/Checkmate/Failed_requests", 0)
 
         if not blocked:
             return None


### PR DESCRIPTION
Add a New Relic custom metric that will allow us to monitor the percentage of Via HTML's Checkmate requests that are failing versus succeeding.