### PR TITLE
Add a Checkmate request to the status endpoint

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -60,7 +60,7 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via -r requirements/requirements.txt
 idna==2.10
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -83,7 +83,7 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via -r requirements/requirements.txt
 idna==2.10
     # via

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,3 +1,4 @@
 pytest
 webtest
+httpretty
 -r requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -63,8 +63,10 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via -r requirements/requirements.txt
+httpretty==1.0.5
+    # via -r requirements/functests.in
 idna==2.10
     # via
     #   -r requirements/requirements.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -86,7 +86,7 @@ h-checkmatelib==1.0.7
     #   -r requirements/tests.txt
 h-matchers==1.2.10
     # via -r requirements/tests.txt
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ greenlet==1.0.0
     # via gevent
 h-checkmatelib==1.0.7
     # via -r requirements/requirements.in
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via -r requirements/requirements.in
 idna==2.10
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -67,7 +67,7 @@ h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
 h-matchers==1.2.10
     # via -r requirements/tests.in
-h_vialib==1.0.13
+h-vialib==1.0.13
     # via -r requirements/requirements.txt
 httpretty==1.0.5
     # via -r requirements/tests.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import httpretty as httpretty_
+import pytest
+
+
 def environment_variables():
     return {
         "VIA_ALLOWED_REFERRERS": ",".join(
@@ -21,3 +25,19 @@ def environment_variables():
         "CHECKMATE_API_KEY": "dev_api_key",
         "CHECKMATE_IGNORE_REASONS": "",
     }
+
+
+@pytest.fixture
+def httpretty():
+    """Monkey-patch Python's socket core module to mock all HTTP responses.
+
+    We never want real HTTP requests to be sent by the tests so replace them
+    all with mock responses. This handles requests sent using the standard
+    urllib2 library and the third-party httplib2 and requests libraries.
+    """
+    httpretty_.enable(allow_net_connect=False)
+
+    yield
+
+    httpretty_.disable()
+    httpretty_.reset()

--- a/tests/functional/viahtml/views/status_test.py
+++ b/tests/functional/viahtml/views/status_test.py
@@ -1,7 +1,25 @@
 import json
 
+import httpretty
+import pytest
 
-def test_status_view_is_connected_correctly(app):
-    response = app.get("/_status")
 
-    assert json.loads(response.body) == {"status": "okay"}
+@pytest.mark.usefixtures("httpretty")
+class TestStatusView:
+    def test_it(self, app):
+        httpretty.register_uri(
+            httpretty.GET, "http://checkmate.example.com/api/check", status=204
+        )
+
+        response = app.get("/_status")
+
+        assert json.loads(response.body) == {"status": "okay"}
+
+    def test_it_when_calling_checkmate_fails(self, app):
+        httpretty.register_uri(
+            httpretty.GET, "http://checkmate.example.com/api/check", status=500
+        )
+
+        response = app.get("/_status")
+
+        assert json.loads(response.body) == {"status": "checkmate_failure"}

--- a/tests/unit/viahtml/views/blocklist_test.py
+++ b/tests/unit/viahtml/views/blocklist_test.py
@@ -1,51 +1,45 @@
 from http import HTTPStatus
-from unittest.mock import sentinel
+from unittest.mock import create_autospec, sentinel
 
 import pytest
-from checkmatelib.exceptions import CheckmateException
+from checkmatelib import CheckmateClient, CheckmateException
 
 from viahtml.views.blocklist import BlocklistView
 
 
 class TestBlocklistView:
-    def test_construction(self, CheckmateClient):
-        view = BlocklistView(sentinel.checkmate_host, sentinel.checkmate_api_key)
-
-        CheckmateClient.assert_called_once_with(
-            sentinel.checkmate_host, sentinel.checkmate_api_key
-        )
-        assert view.checkmate == CheckmateClient.return_value
-
-    def test_if_there_is_no_url_it_does_nothing(self, view, context):
+    def test_if_there_is_no_url_it_does_nothing(self, view, context, checkmate):
         context.proxied_url = ""
         result = view(context)
 
         assert result is None
-        view.checkmate.check_url.assert_not_called()
+        checkmate.check_url.assert_not_called()
 
-    def test_if_the_url_is_not_blocked_it_does_nothing(self, view, context):
-        view.checkmate.check_url.return_value = None
+    def test_if_the_url_is_not_blocked_it_does_nothing(self, view, context, checkmate):
+        checkmate.check_url.return_value = None
         context.query_params.get.return_value = sentinel.blocked_for
 
         result = view(context)
 
         assert result is None
-        view.checkmate.check_url.assert_called_once_with(
+        checkmate.check_url.assert_called_once_with(
             context.proxied_url,
             allow_all=True,
             blocked_for=sentinel.blocked_for,
             ignore_reasons=None,
         )
 
-    def test_if_a_call_to_checkmate_fails_it_does_nothing(self, view, context):
-        view.checkmate.check_url.side_effect = CheckmateException
+    def test_if_a_call_to_checkmate_fails_it_does_nothing(
+        self, view, context, checkmate
+    ):
+        checkmate.check_url.side_effect = CheckmateException
 
         result = view(context)
 
         assert result is None
 
-    def test_blocking(self, view, context):
-        blocked_response = view.checkmate.check_url.return_value
+    def test_blocking(self, view, context, checkmate):
+        blocked_response = checkmate.check_url.return_value
         blocked_response.reason_codes = ["some_reason"]
 
         result = view(context)
@@ -58,10 +52,9 @@ class TestBlocklistView:
         assert result == context.make_response.return_value
 
     @pytest.fixture
-    def view(self):
-        return BlocklistView(sentinel.checkmate_host, sentinel.checkmate_api_key)
+    def view(self, checkmate):
+        return BlocklistView(checkmate)
 
-
-@pytest.fixture(autouse=True)
-def CheckmateClient(patch):
-    return patch("viahtml.views.blocklist.CheckmateClient")
+    @pytest.fixture
+    def checkmate(self):
+        return create_autospec(CheckmateClient, instance=True, spec_set=True)

--- a/tests/unit/viahtml/views/status_test.py
+++ b/tests/unit/viahtml/views/status_test.py
@@ -1,4 +1,8 @@
+from unittest.mock import create_autospec
+
 import pytest
+from checkmatelib import CheckmateClient, CheckmateException
+from h_matchers import Any
 
 from viahtml.views.status import StatusView
 
@@ -12,22 +16,45 @@ class TestStatusView:
             ("/http://example.com", False),
         ),
     )
-    def test_it_responds_to_the_status_url(self, path, responds, context):
+    def test_it_responds_to_the_status_url(self, path, responds, context, view):
         context.path = path
-        StatusView()(context)
+        view(context)
 
         if responds:
             context.make_json_response.assert_called_once()
         else:
             context.make_json_response.assert_not_called()
 
-    def test_it_returns_the_expected_response(self, context):
-        context.path = "/_status"
-
-        response = StatusView()(context)
+    def test_it_returns_the_expected_response(self, context, view):
+        response = view(context)
 
         context.make_json_response.assert_called_once_with(
             {"status": "okay"},
             headers={"Cache-Control": "max-age=0, must-revalidate, no-cache, no-store"},
         )
         assert response == context.make_json_response.return_value
+
+    def test_if_calling_checkmate_fails_it_reports_a_failure(
+        self, checkmate, context, view
+    ):
+        checkmate.check_url.side_effect = CheckmateException
+
+        response = view(context)
+
+        context.make_json_response.assert_called_once_with(
+            {"status": "checkmate_failure"}, headers=Any.dict()
+        )
+        assert response == context.make_json_response.return_value
+
+    @pytest.fixture
+    def checkmate(self):
+        return create_autospec(CheckmateClient, instance=True, spec_set=True)
+
+    @pytest.fixture
+    def context(self, context):
+        context.path = "/_status"
+        return context
+
+    @pytest.fixture
+    def view(self, checkmate):
+        return StatusView(checkmate)

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+from checkmatelib import CheckmateClient
 from pkg_resources import resource_filename
 from pywb.apps.frontendapp import FrontEndApp
 
@@ -31,17 +32,17 @@ class Application:
         self._setup_logging(config["debug"])
         self.hooks = Hooks(config)
 
+        checkmate = CheckmateClient(
+            config["checkmate_host"], config["checkmate_api_key"]
+        )
+
         self.views = (
-            StatusView(),
+            StatusView(checkmate),
             AuthenticationView(
                 required=not config["disable_authentication"],
                 allowed_referrers=config["allowed_referrers"],
             ),
-            BlocklistView(
-                config["checkmate_host"],
-                config["checkmate_api_key"],
-                config["checkmate_ignore_reasons"],
-            ),
+            BlocklistView(checkmate, config["checkmate_ignore_reasons"]),
             RoutingView(config["routing_host"]),
         )
 

--- a/viahtml/views/blocklist.py
+++ b/viahtml/views/blocklist.py
@@ -2,14 +2,14 @@
 
 from http import HTTPStatus
 
-from checkmatelib import CheckmateClient, CheckmateException
+from checkmatelib import CheckmateException
 
 
 class BlocklistView:
     """A view which checks for blocked pages and returns a blocked page."""
 
-    def __init__(self, checkmate_host, checkmate_api_key, ignore_reasons=None):
-        self.checkmate = CheckmateClient(checkmate_host, checkmate_api_key)
+    def __init__(self, checkmate, ignore_reasons=None):
+        self._checkmate = checkmate
         self._ignore_reasons = ignore_reasons
 
     def __call__(self, context):
@@ -24,7 +24,7 @@ class BlocklistView:
 
         blocked_for = context.query_params.get("via.blocked_for")
         try:
-            blocked = self.checkmate.check_url(
+            blocked = self._checkmate.check_url(
                 url,
                 allow_all=True,
                 blocked_for=blocked_for,

--- a/viahtml/views/status.py
+++ b/viahtml/views/status.py
@@ -1,8 +1,16 @@
 """The status end-point for health checks."""
+from logging import getLogger
+
+from checkmatelib import CheckmateException
+
+LOG = getLogger(__name__)
 
 
 class StatusView:
     """Status end-point."""
+
+    def __init__(self, checkmate):
+        self._checkmate = checkmate
 
     def __call__(self, context):
         """Provide a status response if required.
@@ -11,10 +19,18 @@ class StatusView:
         :return: An iterator of content if required or None
         """
         if context.path.rstrip("/") != "/_status":
-            # We don't want to handle this call
+            # We don't want to handle this call.
             return None
 
+        status = "okay"
+
+        try:
+            self._checkmate.check_url("https://example.com/")
+        except CheckmateException:
+            status = "checkmate_failure"
+            LOG.exception("Checkmate request failed")
+
         return context.make_json_response(
-            {"status": "okay"},
+            {"status": status},
             headers={"Cache-Control": "max-age=0, must-revalidate, no-cache, no-store"},
         )


### PR DESCRIPTION
This will allow us to create a Pingdom alarm for if these Checkmate requests are failing.

See https://github.com/hypothesis/checkmate/issues/190

## How I intend for this to be used

I think we should configure our Pingdom status checks to expect a 200 OK response (which they do by default) **and to positively expect the full text `{"status": "okay"}` in the response body**.

Pingdom will only alarm if this check persistently fails every minute for 5 minutes, which should avoid false alarms created by the small percentage of Checkmate requests that are failing under normal conditions.

### Why check the response body and not just the HTTP status code?

Apps can return a 200 OK so that Elastic Beanstalk will not consider them unhealthy (and will not refuse to deploy etc) but still return some body other than `{"status": "okay"}` so that Pingdom will set off an alarm. The Via's want to do this when their Checkmate requests are failing. It might also be useful for some of the other apps too.

### Why assert that the response body has to be `{"status": "okay"}`?

I think a positive check is right for an alarm: `{"status": "okay"}` is the app's way of saying "everything is good" and if the app in any way fails to say that, the alarm should go off. This is safer than checking for the _absence_ of a string like `checkmate_failure` as that requires the app to positively succeed in reporting the failure in the way that the alarm expects, in order to trigger the alarm. For example if something else has gone wrong with the status endpoint (e.g. at the NGINX or Pyramid level) so that it's no longer hitting the status view correctly but is still return 200 OK, an alarm that expects to see the status view's specific `{"status": "okay"}` response will still trigger.

### This is not compatible with reporting on the individual statuses of sub-components

Pingdom can only check for the presence or absence of a string anywhere in the response body. It's not JSON-aware. A response like this is actually saying that the app is down because a critical sub-component is down, but because it's _also_ reporting that a non-critical sub-component is okay the response actually does contain the text `{"status": "okay"}` so the Pingdom check will pass and the alarm will fail to trigger:

```json
{
  "status": "down",
  "components": {
    "critical_component": {"status": "down"},
    "non_critical_component": {"status": "okay"}
  }
}
```

### More informative status endpoints aren't today's problem

I can see some potential utility in apps having more informative status endpoints that report on the statuses of different sub-components individually. I think h is the best example here: most of our apps (including Via) only have one sub-component to check on so really have no need for a multi-component response format. The only exceptions are Checkmate (could check on Postgres and Rabbit) and h. Neither of them do check multiple components currently. But this is how an h status endpoint response might look:

```json
{
  "status": "down",
  "components": {
    "postgres": {"status": "okay"},
    "elasticsearch": {"status": "okay"},
    "rabbit": {"status": "down"}
  }
}
```

In h's case all three components are critical so if any one of them is down h is down. This would be different in Checkmate's case where RabbitMQ is arguably not critical.

This would not be useful for alarming purposes: if Postgres or Elasticsearch was down then requests would be failing and existing alarms would already be going off (error rate, Elastic Beanstalk health). If Rabbit were down then h's job queue-based alarms would be going off. These are better alarms than status endpoint-based ones.

So this would only be useful for informational purposes: if alarms are going off and we're responding to an incident, we might visit the status endpoint for a quick report on what is and isn't working.

I believe the utility here is minimal because we already have multiple informational sources that will be telling us if Postgres, Elasticsearch or Rabbit is down: logs in Papertrail, crash reports in Sentry, New Relic's monitoring (which is aware of Postgres, Elastic and Rabbit). Postgres, Elastic and Rabbit also have their own monitoring. But I can see a status endpoint being a handy additional quick check. 

I think there are a bunch of potential problems with status endpoints like these that we would have to solve:

* They aren't trivially compatible with Pingdom if we want `{"status": "okay"}` to cause the Pingdom check to pass
* It would have to be implemented carefully enough that it still responds (and doesn't itself crash) when components are down while also reporting accurately (not saying that things are down when they aren't, e.g. by having too-tight timeouts).
* A status endpoint can be too slow if it spends too much time opening and closing connections and checking things. I'm not sure what Pingdom's timeout is (it doesn't appear to be configurable). We have New Relic status endpoint checks that have to respond within 1500ms including round-trip time from different locations around the world. Our current simple status endpoints are already not fast: they are currently taking 400-1300ms across our apps (according to Pingdom). This can cause false alarms that wake people up
* A status endpoint can take up too many resources, e.g. if it opens and closes too many connections, if multiple checks can take too long waiting for things to time out when components are down, if a script is hammering a status endoint, etc. This can disrupt the rest of the app
* Multi-component status endpoints will encourage us to add checks for all potentially interesting components but this might not be a good idea. For example Rabbit is a non-critical component for Checkmate. We don't want to wake people up if Checkmate's Rabbit is failing
* The design and implementation of status endpoints and their tests can occupy too much developer time and distract from more important things
* More things will probably come up

While I think all of the above problems are solveable I think introducing more complex status endpoints _does_ create new problems for us to spend time solving and I'd like to kick that can down the road: we don't need this for Via which only has one component to report on.

I think the `{"status": "checkmate_failure"}` response in this PR is extensible into a more complex format in future. I can imagine a future status endpoints design where possible responses included:

1. `{"status": "okay"}` 

2. Basic: `{"status": "down"}` (not sure you'd ever do this)

3. Slightly more informative (this PR): `{"status": "checkmate_failure"}` 

4. Even more informative, multiple components (not really useful for Via which only has one component to check):

   ```json
   {
     "status": "down",
     "components": {
       "postgres": {"status": "okay"},
       "elasticsearch": {"status": "okay"},
       "rabbit": {"status": "down"}
     }
   }
   ```

   And this could be taken even further by adding more details about each component beyond just the status.

I'd like to kick deciding whether or not `4` is a good idea and figuring out how to do it down the road for now.