### PR TITLE
Just importing httpretty breaks the functional tests

### DIFF
--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,3 +1,4 @@
 pytest
 webtest
+httpretty
 -r requirements.txt

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -65,6 +65,8 @@ h-checkmatelib==1.0.7
     # via -r requirements/requirements.txt
 h_vialib==1.0.13
     # via -r requirements/requirements.txt
+httpretty==1.0.5
+    # via -r requirements/functests.in
 idna==2.10
     # via
     #   -r requirements/requirements.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import httpretty
+
+
 def environment_variables():
     return {
         "VIA_ALLOWED_REFERRERS": ",".join(


### PR DESCRIPTION
Just importing `httpretty` in `tests/conftest.py` or `tests/functional/conftest.py` breaks the functional tests. See the [outcome of the functional tests on this branch](https://github.com/hypothesis/viahtml/pull/140/checks?check_run_id=2324447202). I can reproduce locally too