### PR TITLE
Optionally use Checkmate's allow-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Environment variables:
 |------|--------|---------|
 | `CHECKMATE_URL`       | The URL of the URL checking service       | `https://some-aws-machine` |
 | `CHECKMATE_API_KEY`   | API key to authenticate with checkmate    | `dev_api_key` |
+| `CHECKMATE_ALLOW_ALL`   | Whether to bypass Checkmate's allow-list | true |
 | `CHECKMATE_IGNORE_REASONS`   | Ignored reasons on checkmate detections    | `reason1,reason2` |
 | `VIA_DEBUG`           | Enable debugging logging in dev           | `1` |
 | `VIA_H_EMBED_URL`     | Hypothesis client URL                     | `https://cdn.hypothes.is/hypothesis` |

--- a/tests/unit/viahtml/views/blocklist_test.py
+++ b/tests/unit/viahtml/views/blocklist_test.py
@@ -24,7 +24,7 @@ class TestBlocklistView:
         assert result is None
         checkmate.check_url.assert_called_once_with(
             context.proxied_url,
-            allow_all=True,
+            allow_all=sentinel.allow_all,
             blocked_for=sentinel.blocked_for,
             ignore_reasons=None,
         )
@@ -53,7 +53,7 @@ class TestBlocklistView:
 
     @pytest.fixture
     def view(self, checkmate):
-        return BlocklistView(checkmate)
+        return BlocklistView(checkmate, sentinel.allow_all)
 
     @pytest.fixture
     def checkmate(self):

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: CHECKMATE_URL = http://localhost:9099
     dev: CHECKMATE_API_KEY = dev_api_key
+    dev: CHECKMATE_ALLOW_ALL = {env:CHECKMATE_ALLOW_ALL:true}
     dev: CHECKMATE_IGNORE_REASONS = {env:CHECKMATE_IGNORE_REASONS:publisher-blocked}
     dev: VIA_BLOCKLIST_PATH = conf/blocklist-dev.txt
     dev: VIA_DISABLE_AUTHENTICATION = 0

--- a/viahtml/app.py
+++ b/viahtml/app.py
@@ -49,7 +49,11 @@ class Application:
                 required=not config["disable_authentication"],
                 allowed_referrers=config["allowed_referrers"],
             ),
-            BlocklistView(checkmate, config["checkmate_ignore_reasons"]),
+            BlocklistView(
+                checkmate,
+                asbool(config.get("checkmate_allow_all")),
+                config["checkmate_ignore_reasons"],
+            ),
             RoutingView(config["routing_host"]),
         )
 
@@ -113,6 +117,7 @@ class Application:
             "checkmate_host": os.environ["CHECKMATE_URL"],
             "checkmate_ignore_reasons": os.environ.get("CHECKMATE_IGNORE_REASONS"),
             "checkmate_api_key": os.environ["CHECKMATE_API_KEY"],
+            "checkmate_allow_all": os.environ.get("CHECKMATE_ALLOW_ALL"),
         }
 
     @classmethod

--- a/viahtml/views/blocklist.py
+++ b/viahtml/views/blocklist.py
@@ -8,8 +8,22 @@ from checkmatelib import CheckmateException
 class BlocklistView:
     """A view which checks for blocked pages and returns a blocked page."""
 
-    def __init__(self, checkmate, ignore_reasons=None):
+    def __init__(self, checkmate, allow_all, ignore_reasons=None):
+        """Initialize a new BlocklistView.
+
+        :param checkmate: the Checkmate client object
+        :type checkmate: checkmatelib.CheckmateClient
+
+        :param allow_all: whether to bypass Checkmate's allow list
+        :type allow_all_: bool
+
+        :param ignore_reasons: comma-separated list of Checkmate
+            "detection reasons" to ignore, for example:
+            "publisher-blocked,high-io"
+        :type ignore_reasons: str
+        """
         self._checkmate = checkmate
+        self._allow_all = allow_all
         self._ignore_reasons = ignore_reasons
 
     def __call__(self, context):
@@ -26,7 +40,7 @@ class BlocklistView:
         try:
             blocked = self._checkmate.check_url(
                 url,
-                allow_all=True,
+                allow_all=self._allow_all,
                 blocked_for=blocked_for,
                 ignore_reasons=self._ignore_reasons,
             )


### PR DESCRIPTION
Add a `CHECKMATE_ALLOW_ALL` envvar that controls whether Via HTML uses Checkmate's allow list or just the blocklist.

`CHECKMATE_ALLOW_ALL` is `False` by default (meaning _do_ use the allow-list) so we'll have to add `CHECKMATE_ALLOW_ALL=true` to LMS's QA and prod instances of Via HTML before we deploy this.

This is the same as done for Via 3 here:

https://github.com/hypothesis/via3/pull/435/

Fixes https://github.com/hypothesis/checkmate/issues/133