### PR TITLE
Add Via 3 to the allowed referrers in dev

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -91,7 +91,7 @@ py-tracebacker = /tmp/via-traceback-
 # stats-no-cores=true
 
 # Via config
-env = VIA_ALLOWED_REFERRERS=localhost:8001,localhost:9101
+env = VIA_ALLOWED_REFERRERS=localhost:8001,localhost:9083,localhost:9101
 env = VIA_H_EMBED_URL=http://localhost:3001/hypothesis
 env = VIA_IGNORE_PREFIXES=http://localhost:5000/,http://localhost:3001/,https://localhost:5000/,https://localhost:3001/
 env = VIA_DEBUG=1


### PR DESCRIPTION
We're going to be adding a legacy Via-style front page to Via 3 where you can paste in a URL to proxy. If the URL is to an HTML page this Via 3 front page will redirect the browser to Via HTML. In order for this to work Via 3 needs to be on Via HTML's allowed referrers list.

(We'll need to add QA and prod Via 3 to QA and prod Via HTML's allowed referrers envvars too.)