### PR TITLE
Tweak status endpoint

### DIFF
--- a/tests/functional/viahtml/views/status_test.py
+++ b/tests/functional/viahtml/views/status_test.py
@@ -15,11 +15,8 @@ class TestStatusView:
 
         response = app.get(
             "/_status",
-            params="checkmate",
+            params="include-checkmate",
             status=500,  # The status endpoint reports failure.
         )
 
-        assert json.loads(response.body) == {
-            "status": "down",
-            "components": {"checkmate": {"status": "down"}},
-        }
+        assert json.loads(response.body) == {"status": "down", "down": ["checkmate"]}

--- a/tests/unit/viahtml/views/status_test.py
+++ b/tests/unit/viahtml/views/status_test.py
@@ -36,20 +36,10 @@ class TestStatusView:
             # succeeds even if Checkmate is failing.
             (True, False, {"status": "okay"}, 200),
             # If the `checkmate` query param is given then it checks Checkmate.
-            (
-                False,
-                True,
-                {"status": "okay", "components": {"checkmate": {"status": "okay"}}},
-                200,
-            ),
+            (False, True, {"status": "okay", "okay": ["checkmate"]}, 200),
             # With the `checkmate` query param if Checkmate fails then the
             # status endpoint fails.
-            (
-                True,
-                True,
-                {"status": "down", "components": {"checkmate": {"status": "down"}}},
-                500,
-            ),
+            (True, True, {"status": "down", "down": ["checkmate"]}, 500),
         ],
     )
     def test_it(
@@ -66,7 +56,7 @@ class TestStatusView:
             checkmate.check_url.side_effect = CheckmateException
 
         if checkmate_param:
-            context.query_params = {"checkmate": [""]}
+            context.query_params = {"include-checkmate": [""]}
 
         response = view(context)
 


### PR DESCRIPTION
Tweak the status endpoint response format and query param to be a little more general and work better with Pingdom.

Implements the changes suggested here:

https://github.com/hypothesis/viahtml/pull/139#issuecomment-818892434

Pingdom will look for a 200 OK response containing the string `"okay": ["checkmate"]`.

Demo:

    $ http --pretty none 'http://localhost:9085/_status'
    HTTP/1.1 200 OK
    Server: nginx/1.17.6
    Date: Wed, 14 Apr 2021 16:21:04 GMT
    Content-Type: application/json; charset=utf-8
    Transfer-Encoding: chunked
    Connection: keep-alive
    Cache-Control: max-age=0, must-revalidate, no-cache, no-store
    X-Via: html

    {"status": "okay"}

    $ http --pretty none 'http://localhost:9085/_status?include-checkmate'
    HTTP/1.1 500 Internal Server Error
    Server: nginx/1.17.6
    Date: Wed, 14 Apr 2021 16:21:09 GMT
    Content-Type: application/json; charset=utf-8
    Transfer-Encoding: chunked
    Connection: keep-alive
    Cache-Control: max-age=0, must-revalidate, no-cache, no-store

    {"status": "down", "down": ["checkmate"]}

    $ http --pretty none 'http://localhost:9085/_status?include-checkmate'
    HTTP/1.1 200 OK
    Server: nginx/1.17.6
    Date: Wed, 14 Apr 2021 16:21:21 GMT
    Content-Type: application/json; charset=utf-8
    Transfer-Encoding: chunked
    Connection: keep-alive
    Cache-Control: max-age=0, must-revalidate, no-cache, no-store
    X-Via: html

    {"status": "okay", "okay": ["checkmate"]}