### PR TITLE
Log Checkmate exceptions to Sentry

### DIFF
--- a/viahtml/views/blocklist.py
+++ b/viahtml/views/blocklist.py
@@ -1,5 +1,6 @@
 """The blocklist view."""
 
+import logging
 from http import HTTPStatus
 
 from checkmatelib import CheckmateException
@@ -45,6 +46,7 @@ class BlocklistView:
                 ignore_reasons=self._ignore_reasons,
             )
         except CheckmateException:
+            logging.exception("Failed to check URL against Checkmate")
             blocked = None
 
         if not blocked:


### PR DESCRIPTION
We previously removed this logging when we gave up on using Sentry to set an alarm for it (https://github.com/hypothesis/viahtml/pull/121/). I want to put the logging back so we can keep an eye on these failures and try out ideas for stopping them.