### PR TITLE
Don't disable PyLint's unused-argument warning

### DIFF
--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -22,7 +22,6 @@ disable=bad-continuation,
         no-value-for-parameter,
         redefined-outer-name,
         too-few-public-methods,
-        unused-argument,
 
 [REPORTS]
 output-format=colorized

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -18,7 +18,7 @@ from viahtml.app import Application
 
 
 @pytest.fixture(scope="session")
-def app(with_environ):
+def app(with_environ):  # pylint:disable=unused-argument
     app = Application()
     app.debug = True
 

--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -32,7 +32,7 @@ class TestProxy:
 
         assert policy == "*MISSING*"
 
-    def test_we_dont_rewrite_links_by_default(self, app, proxied_content):
+    def test_we_dont_rewrite_links_by_default(self, proxied_content):
         assert '<a href="http://example.com">link</a>' in proxied_content
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This warning is very useful for finding unused fixtures, we don't want to disable it.