### PR TITLE
Swap out `tox-pip-extensions` for `tox-pip-sync`

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -19,6 +19,7 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:report_metrics]
+environment=PYTHONPATH=.
 command=python bin/report_metrics.py
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ passenv =
     dev: CLIENT_EMBED_URL
     dev: LEGACY_VIA_URL
 deps =
-    dev: -e .
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt
     functests: -r requirements/functests.txt


### PR DESCRIPTION
This gets around `pip-tools` limitations.

### Testing notes

 * `rm -rf .tox/`
 * `git checkout master`
 * `make sure`
 * `git checkout use-tox-pip-sync`
 * `make sure`
 * Everything should be fine