### PR TITLE
Add abuse policy response headers

### DIFF
--- a/tests/unit/viahtml/hooks/_headers_test.py
+++ b/tests/unit/viahtml/hooks/_headers_test.py
@@ -21,6 +21,17 @@ class TestHeaders:
         assert Headers.environ_name(header_name) not in http_env
         assert "HTTP_OTHER_HEADER" in http_env
 
+    def test_modify_inbound_inserts_abuse_headers(self, headers):
+        http_env = {"HTTP_OTHER_HEADER": "ok"}
+
+        http_env = headers.modify_inbound(http_env)
+
+        assert http_env == {
+            "HTTP_OTHER_HEADER": "ok",
+            "HTTP_X_ABUSE_POLICY": "https://web.hypothes.is/abuse-policy/",
+            "HTTP_X_COMPLAINTS_TO": "https://web.hypothes.is/report-abuse/",
+        }
+
     @pytest.mark.parametrize(
         "header_name", Headers.BLOCKED_OUTBOUND | {"X-Archive-Anything-At-All"}
     )

--- a/viahtml/hooks/_headers.py
+++ b/viahtml/hooks/_headers.py
@@ -72,6 +72,9 @@ class Headers:
         for bad_key in bad_keys:
             http_env.pop(bad_key)
 
+        http_env["HTTP_X_ABUSE_POLICY"] = "https://web.hypothes.is/abuse-policy/"
+        http_env["HTTP_X_COMPLAINTS_TO"] = "https://web.hypothes.is/report-abuse/"
+
         return http_env
 
     def modify_outbound(self, header_items):


### PR DESCRIPTION
This adds X-Abuse-Policy and X-Complaints-To headers to Via HTML's
responses.

Part of hypothesis/checkmate#70

See this Slack thread for the choice of headers:
https://hypothes-is.slack.com/archives/C4K6M7P5E/p1619616535474700?thread_ts=1619615485.468500&cid=C4K6M7P5E