### PR TITLE
Report proxied URL to parent frame

### DIFF
--- a/viahtml/templates/banner.html
+++ b/viahtml/templates/banner.html
@@ -3,6 +3,8 @@
 
 <!-- Inject Hypothesis -->
 <script type="application/javascript">
+    const proxiedURL = {{ cdx.url | tojson }};
+
     /**
       * Return `true` if this frame has no ancestors or its nearest ancestor was
       * not served through Via.
@@ -117,7 +119,11 @@
       let prevMetadata = {};
       const checkMetadata = () => {
         const currentMetadata = {
-          location: location.href,
+          // Report the URL of the document we are proxying to the Via3 parent
+          // frame. A limitation of this is that it doesn't reflect any URL
+          // changes made by the web application using the History API.
+          location: proxiedURL,
+
           title: document.title,
         }
         if (!shallowEqual(prevMetadata, currentMetadata)) {


### PR DESCRIPTION
Report the URL of the proxied web page to the via3 parent frame rather
than the ViaHTML URL. eg. `https://example.com` instead of
`https://viahtml.hypothes.is/proxy/https://example.com`.

This will be used by via3 to reflect the current document URL in the URL
bar, as it may be different than the initially requested URL if a
redirect happened.

Part of https://github.com/hypothesis/viahtml/issues/156