### PR TITLE
Upgrade to h-vialib version 1.0.17

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -56,7 +56,7 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.9
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via -r requirements/requirements.txt
 idna==2.10
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements/dev.in
 #
+appnope==0.1.2
+    # via ipython
 attrs==20.3.0
     # via
     #   -r requirements/requirements.txt
@@ -77,7 +79,7 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.9
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via -r requirements/requirements.txt
 idna==2.10
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -59,7 +59,7 @@ greenlet==1.0.0
     #   gevent
 h-checkmatelib==1.0.9
     # via -r requirements/requirements.txt
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via -r requirements/requirements.txt
 httpretty==1.1.3
     # via -r requirements/functests.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -81,7 +81,7 @@ h-checkmatelib==1.0.9
     #   -r requirements/tests.txt
 h-matchers==1.2.11
     # via -r requirements/tests.txt
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -34,7 +34,7 @@ greenlet==1.0.0
     # via gevent
 h-checkmatelib==1.0.9
     # via -r requirements/requirements.in
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via -r requirements/requirements.in
 idna==2.10
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -63,7 +63,7 @@ h-checkmatelib==1.0.9
     # via -r requirements/requirements.txt
 h-matchers==1.2.11
     # via -r requirements/tests.in
-h-vialib==1.0.15
+h-vialib==1.0.17
     # via -r requirements/requirements.txt
 httpretty==1.1.3
     # via -r requirements/tests.in


### PR DESCRIPTION
I used `hdev requirements --package h-vialib`

Version 1.0.17 whitelists the `ignoreOtherConfiguration` so it can
disregard other hypothesis configurations included in the host page.