### PR TITLE
Don't try to include JS no longer present in pywb

### DIFF
--- a/bin/build_static.py
+++ b/bin/build_static.py
@@ -8,7 +8,6 @@ import importlib_resources
 # All the pywb resources we know we need
 MANIFEST = (
     "autoFetchWorker.js",
-    "autoFetchWorkerProxyMode.js",
     "default_banner.js",
     "flowplayer/toolbox.flashembed.js",
     "js/bootstrap.min.js",
@@ -23,7 +22,6 @@ MANIFEST = (
     "wombat.js",
     "wombatProxyMode.js",
     "wombatWorkers.js",
-    "ww_rw.js",
 )
 
 


### PR DESCRIPTION
This matches all .js files currently present on pywb/static

Currently broken after merging: https://github.com/hypothesis/viahtml/pull/228

## Testing notes

 * `make build`
 * 'tis broken