### PR TITLE
Allow fragment only URLs to remain as is on a page

### DIFF
--- a/tests/unit/viahtml/context_test.py
+++ b/tests/unit/viahtml/context_test.py
@@ -159,10 +159,12 @@ class TestContext:
                 True,
                 "http://via/proxy/http://example.com",
             ),
+            ("#fragment", True, "http://via/proxy/https://example.com/path/#fragment"),
             ("subpath", False, "https://example.com/path/subpath"),
             ("/path2", False, "https://example.com/path2"),
             ("//example.com", False, "https://example.com"),
             ("ftp://example.com", False, "ftp://example.com"),
+            ("#fragment", False, "https://example.com/path/#fragment"),
         ),
     )
     def test_make_absolute(
@@ -171,6 +173,18 @@ class TestContext:
         environ["PATH_INFO"] = "/proxy/https://example.com/path/"
 
         result = context.make_absolute(url, proxy)
+
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "url,expected", (("#fragment", "#fragment"), ("/path", "http://via/path"))
+    )
+    def test_make_absolute_with_rewrite_fragments_disabled(
+        self, context, url, expected, environ
+    ):
+        environ["PATH_INFO"] = "/proxy/https://example.com/path/"
+
+        result = context.make_absolute(url, rewrite_fragments=False)
 
         assert result == expected
 

--- a/viahtml/context.py
+++ b/viahtml/context.py
@@ -147,7 +147,7 @@ class Context:
         wsgi_name = "HTTP_" + name.upper().replace("-", "_")
         return self.http_environ.get(wsgi_name)
 
-    def make_absolute(self, url, proxy=True):
+    def make_absolute(self, url, proxy=True, rewrite_fragments=True):
         """Make a URL absolute.
 
         Any URL which is already absolute will be returned as is, regardless
@@ -156,6 +156,10 @@ class Context:
         :param url: URL to convert
         :param proxy: Make the path relative with regards to Via rather than
             the original site
+        :param rewrite_fragments: Enable making fragment only URLs absolute
         :return: An absolute URL to our service
         """
+        if not rewrite_fragments and url.startswith("#"):
+            return url
+
         return urljoin(self.url if proxy else self.proxied_url, url)

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -100,7 +100,7 @@ class Hooks:
         # (not proxied by Via).
         if tag == "a":
             rewrites["href"] = lambda value: self.context.make_absolute(
-                value, proxy=False
+                value, proxy=False, rewrite_fragments=False
             )
             stop = True
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/product-backlog/issues/1307
* https://github.com/hypothesis/viahtml/issues/297

This is part of work to allow local navigation about a page, but not if it goes off of the page. Currently the PR only address the rewriting portion, and means the plan fragment only urls like `#anchor` remain as is.

A the moment there is also a Javascript portion that will need to be addressed which cases the link to pop open into a new tab.

# Testing notes

 * Start Via and ViaHTML
 * Visit http://localhost:9083
 * Type in the following address: https://jeffreycwitt.com/pl339/docs/02-the-medium-is-the-message.html
 * Inspect the links in the table of contents using F12
 * They should be plain anchors (in main they are rewritten)