### PR TITLE
Fix fragment links being treated as external links (client side)

### DIFF
--- a/viahtml/templates/banner.html
+++ b/viahtml/templates/banner.html
@@ -44,30 +44,40 @@
       }
     }
 
-    function stripFragment(url) {
-      return url.replace(/#.*$/, '');
+    function stripFragmentAndViaParams(url) {
+      const parsed = new URL(url);
+      parsed.hash = '';
+
+      // nb. Keys are copied to avoid incorrect result if params are modified
+      // during iteration.
+      for (let key of [...parsed.searchParams.keys()]) {
+        if (key.startsWith('via.')) {
+          parsed.searchParams.delete(key);
+        }
+      }
+
+      return parsed.toString();
     }
 
     /**
      * Test if a link will navigate to a new page as opposed to scrolling to a
      * different location within the current page.
      *
+     * The logic a browser uses to decide this is specified in
+     * https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate (step 8).
+     *
      * @param {HTMLAnchorElement} linkEl
      */
     function isExternalLink(linkEl) {
-      // Create a link that is definitely internal and compare its absolute URL
-      // to the target link.
+      // `linkEl.href` is monkey-patched by pywb/Wombat to return the proxied
+      // URL so we need to compare that to the proxied URL of the current page,
+      // rather than `location.href`, which will return the proxy URL.
       //
-      // We do this rather than the more obvious comparison of `linkEl.href` to `location.href`
-      // because Via monkey-patches `HTMLAnchorElement.prototype.href` so that it
-      // returns the original (non-proxied) URL and therefore cannot be
-      // compared directly with the real (proxied) URL that `location.href` returns.
-      const internalLink = document.createElement('a');
-
-      // nb. `href` always returns an absolute URL when read.
-      internalLink.href = '#';
-
-      return stripFragment(internalLink.href) !== stripFragment(linkEl.href);
+      // `linkEl.href` may contain "via."-prefixed parameters, whereas `proxiedURL`
+      // does not, so we also need to ignore those.
+      const targetURL = stripFragmentAndViaParams(linkEl.href);
+      const currentURL = stripFragmentAndViaParams(proxiedURL);
+      return currentURL !== targetURL;
     }
 
     /**


### PR DESCRIPTION
The frontend has logic to detect whether a link that is clicked on is an internal or external one, in order to make external links open in a new tab. Following browser behavior (see link in code comments) this involves comparing a link's URL against the current page, ignoring the fragment.

This logic was broken in the current version of wombat/pywb. The approach used to get the proxied URL of the current page did not work due to a bug in pywb/wombat (see commit message for details). This PR uses a different approach that should be more robust.

In addition there was an issue where `via.`-prefixed query parameters are stripped from the URL that pywb receives on the backend to proxy, but are still visible to parts of the pywb frontend JavaScript. When comparing a link's target URL (obtained in a way that does include these params) with the current page's URL (obtained in a way that does not include these params), we need to ignore them.

Closes:
 *  https://github.com/hypothesis/product-backlog/issues/1307
 *  https://github.com/hypothesis/viahtml/issues/297

---

**Testing:**

1. Open viahtml and enter the URL of a page which contains internal / fragment links
2. Click on the fragment links and verify that they scroll the page instead of navigating to a new page

For example, when visiting http://localhost:9083/https://jeffreycwitt.com/pl339/docs/02-the-medium-is-the-message.html, if you click the links in the Table of Contents above the main content, they should now the scroll the page. The links in the left navbar meanwhile should still direct to a new page.