### PR TITLE
Catch `BadURL` errors from Checkmate and present them as a 400

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -50,7 +50,7 @@ greenlet==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-vialib==1.0.18
     # via -r requirements/requirements.txt
@@ -76,6 +76,10 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
+netaddr==0.8.0
+    # via
+    #   -r requirements/requirements.txt
+    #   h-checkmatelib
 newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 portalocker==2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -75,7 +75,7 @@ greenlet==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-vialib==1.0.18
     # via -r requirements/requirements.txt
@@ -114,6 +114,10 @@ markupsafe==1.1.1
     #   pywb
 matplotlib-inline==0.1.2
     # via ipython
+netaddr==0.8.0
+    # via
+    #   -r requirements/requirements.txt
+    #   h-checkmatelib
 newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 paramiko==2.10.1

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -53,7 +53,7 @@ greenlet==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-vialib==1.0.18
     # via -r requirements/requirements.txt
@@ -83,6 +83,10 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
+netaddr==0.8.0
+    # via
+    #   -r requirements/requirements.txt
+    #   h-checkmatelib
 newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 packaging==20.9

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -72,7 +72,7 @@ greenlet==1.0.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -121,6 +121,11 @@ markupsafe==1.1.1
     #   pywb
 mccabe==0.6.1
     # via pylint
+netaddr==0.8.0
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   h-checkmatelib
 newrelic==7.10.0.175
     # via
     #   -r requirements/requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ gevent==20.9.0
     # via pywb
 greenlet==1.0.0
     # via gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.in
 h-vialib==1.0.18
     # via -r requirements/requirements.in
@@ -50,6 +50,8 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   pywb
+netaddr==0.8.0
+    # via h-checkmatelib
 newrelic==7.10.0.175
     # via -r requirements/requirements.in
 portalocker==2.0.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -55,7 +55,7 @@ greenlet==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.10
+h-checkmatelib==1.0.12
     # via -r requirements/requirements.txt
 h-matchers==1.2.13
     # via -r requirements/tests.in
@@ -87,6 +87,10 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
+netaddr==0.8.0
+    # via
+    #   -r requirements/requirements.txt
+    #   h-checkmatelib
 newrelic==7.10.0.175
     # via -r requirements/requirements.txt
 packaging==20.9

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -59,7 +59,7 @@ def upstream_website():
 
     with serve_content(  # pylint: disable=not-context-manager
         minimal_valid_html,
-        port=8080,
+        port=8197,
         extra_headers={"Cache-Control": "public, max-age=60"},
     ):
         yield
@@ -68,7 +68,7 @@ def upstream_website():
 @pytest.fixture
 def proxied_content(app):
     return app.get(
-        "/proxy/http://localhost:8080/?via.client.openSidebar=yup", expect_errors=True
+        "/proxy/http://localhost:8197/?via.client.openSidebar=yup", expect_errors=True
     )
 
 

--- a/tests/functional/fixups_test.py
+++ b/tests/functional/fixups_test.py
@@ -5,12 +5,12 @@ class TestFixupsToPywb:
         # The '_id' here means a transparent rewrite, and no insertion of
         # wombat stuff
         assert (
-            '<link rel="manifest" href="/proxy/id_/http://localhost:8080/manifest.json"'
+            '<link rel="manifest" href="/proxy/id_/http://localhost:8197/manifest.json"'
             in proxied_content
         )
 
     def test_we_do_rewrite_other_rels(self, proxied_content):
         assert (
-            '<link rel="other" href="/proxy/oe_/http://localhost:8080/other.json"'
+            '<link rel="other" href="/proxy/oe_/http://localhost:8197/other.json"'
             in proxied_content
         )

--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -17,7 +17,7 @@ class TestProxy:
 
     def test_client_params_are_stripped_from_the_canonical_url(self, proxied_content):
         assert (
-            '<link rel="canonical" href="http://localhost:8080/"/>' in proxied_content
+            '<link rel="canonical" href="http://localhost:8197/"/>' in proxied_content
         )
 
     def test_ignore_prefixes_are_added_to_the_wombat_config(self, proxied_content):
@@ -43,7 +43,7 @@ class TestProxy:
         ),
     )
     def test_we_set_external_link_mode(self, app, link_mode, expected):
-        url = "/proxy/http://localhost:8080/"
+        url = "/proxy/http://localhost:8197/"
         if link_mode is not None:
             url += f"?via.external_link_mode={link_mode}"
 

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -24,7 +24,7 @@ def threaded_context(function):
 
 
 @threaded_context
-def serve_content(content, content_type="text/html", port=8080, extra_headers=None):
+def serve_content(content, content_type="text/html", port=8197, extra_headers=None):
     """Serve some given content forever with a simple HTTP server.
 
     :param content: Content to serve to GET requests

--- a/viahtml/stats.py
+++ b/viahtml/stats.py
@@ -9,9 +9,6 @@ from requests import RequestException
 LOG = getLogger(__name__)
 
 
-# pylint: disable=missing-yield-doc,missing-yield-type-doc
-
-
 class UWSGINewRelicStatsGenerator:
     """A callable which returns stats from uWSGI stats for New Relic."""
 


### PR DESCRIPTION
Needs:

 * https://github.com/hypothesis/checkmatelib/pull/21

This is some ugly error representation, but it's better than burying them. In general you shouldn't be able to get here without having made a mistake somewhere else.

## Testing notes

At the moment it's quite hard to get `checkmatelib` to raise, so I'd suggest manually bodging `viahtml/views/security.py` to raise an error:

```python
    def __call__(self, context):
 
        ...

        try:
            raise BadURL("TERRIBLE NEWS!")

            blocked = self._is_blocked(
                context.proxied_url,
                context.query_params.get("via.blocked_for"),
                allow_all,
            )
        except BadURL as exc:
            return context.make_response(
        ...
```

 * Then start `via` and `viahthml` with `make dev`
 * Visit: http://localhost:9083
 * Type in any website
 * You should see a pretty plain error page