### PR TITLE
Renamed default branch to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,14 +32,14 @@ node {
         }
     }
 
-    onlyOnMaster {
+    onlyOnMain {
         stage("Release") {
             releaseApp(image: img)
         }
     }
 }
 
-onlyOnMaster {
+onlyOnMain {
     milestone()
     stage("Deploy (qa)") {
 	lock("qa deploy") {

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 jobs=0  # Speed up PyLint by using one process per CPU core.
 load-plugins=pylint.extensions.bad_builtin,
              pylint.extensions.broad_try_clause,


### PR DESCRIPTION
1. Replaced the onlyOnMaster function with onlyOnMain in the Jenkinsfile
2. Replace reference to the master branch with main in tests/.pylintrc