### PR TITLE
Replace `h-checkmatelib` with just `checkmatelib`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -40,6 +40,8 @@ charset-normalizer==2.0.6
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 cryptography==3.3.2
@@ -79,8 +81,6 @@ greenlet==1.1.2
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-vialib==1.0.19
     # via -r requirements/requirements.txt
 idna==2.10
@@ -91,7 +91,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 ipdb==0.13.9
     # via -r requirements/dev.in
 ipython==8.4.0
@@ -109,8 +109,8 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
+    #   checkmatelib
     #   docker-compose
-    #   h-checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -121,7 +121,7 @@ matplotlib-inline==0.1.2
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 packaging==21.3
@@ -195,9 +195,9 @@ redis==2.10.6
 requests==2.26.0
     # via
     #   -r requirements/requirements.txt
+    #   checkmatelib
     #   docker
     #   docker-compose
-    #   h-checkmatelib
     #   pywb
     #   requests-file
     #   tldextract

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -35,6 +35,8 @@ charset-normalizer==2.0.6
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 cryptography==3.3.2
@@ -57,8 +59,6 @@ greenlet==1.1.2
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-vialib==1.0.19
     # via -r requirements/requirements.txt
 httpretty==1.1.4
@@ -71,7 +71,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
@@ -81,7 +81,7 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -90,7 +90,7 @@ markupsafe==1.1.1
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 packaging==20.9
@@ -151,7 +151,7 @@ redis==2.10.6
 requests==2.26.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   pywb
     #   requests-file
     #   tldextract

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -47,6 +47,10 @@ charset-normalizer==2.0.6
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
+checkmatelib==1.0.15
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
 click==8.1.3
     # via
     #   -r requirements/tests.txt
@@ -80,10 +84,6 @@ greenlet==1.1.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   gevent
-h-checkmatelib==1.0.14
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
 h-matchers==1.2.15
     # via -r requirements/tests.txt
 h-vialib==1.0.19
@@ -102,7 +102,7 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via
     #   -r requirements/tests.txt
@@ -118,7 +118,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
@@ -133,7 +133,7 @@ netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via
     #   -r requirements/requirements.txt
@@ -225,7 +225,7 @@ requests==2.26.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   pywb
     #   requests-file
     #   tldextract

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-h-checkmatelib
+checkmatelib
 h-vialib
 importlib-resources
 newrelic

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,6 +20,8 @@ cffi==1.14.2
     #   cryptography
 charset-normalizer==2.0.6
     # via requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.in
 cryptography==3.3.2
     # via pyopenssl
 defusedxml==0.6.0
@@ -30,8 +32,6 @@ gevent==21.12.0
     # via pywb
 greenlet==1.1.2
     # via gevent
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.in
 h-vialib==1.0.19
     # via -r requirements/requirements.in
 idna==2.10
@@ -41,17 +41,17 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.in
-    #   h-checkmatelib
+    #   checkmatelib
 jinja2==2.11.3
     # via pywb
 jsonschema==3.2.0
-    # via h-checkmatelib
+    # via checkmatelib
 markupsafe==1.1.1
     # via
     #   jinja2
     #   pywb
 netaddr==0.8.0
-    # via h-checkmatelib
+    # via checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.in
 portalocker==2.0.0
@@ -78,7 +78,7 @@ redis==2.10.6
     #   pywb
 requests==2.26.0
     # via
-    #   h-checkmatelib
+    #   checkmatelib
     #   pywb
     #   requests-file
     #   tldextract

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -35,6 +35,8 @@ charset-normalizer==2.0.6
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
 coverage==6.4.4
@@ -59,8 +61,6 @@ greenlet==1.1.2
     # via
     #   -r requirements/requirements.txt
     #   gevent
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-matchers==1.2.15
     # via -r requirements/tests.in
 h-vialib==1.0.19
@@ -75,7 +75,7 @@ idna==2.10
 importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
@@ -85,7 +85,7 @@ jinja2==2.11.3
 jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -94,7 +94,7 @@ markupsafe==1.1.1
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 packaging==20.9
@@ -155,7 +155,7 @@ redis==2.10.6
 requests==2.26.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   pywb
     #   requests-file
     #   tldextract


### PR DESCRIPTION
`h-checkmatelib` has been renamed to just `checkmatelib`:

hypothesis/checkmatelib#24

This commit is the result of replace `h-checkmatelib` with `checkmatelib` in `requirements.in` and then running `make requirements`.
