### PR TITLE
Upgrade `cryptography` and `pyopenssl`

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -36,7 +36,7 @@ checkmatelib==1.0.15
     # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
-cryptography==3.3.2
+cryptography==38.0.1
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
@@ -155,7 +155,6 @@ sentry-sdk==1.9.0
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
-    #   cryptography
     #   jsonschema
     #   pyopenssl
     #   python-dateutil

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ checkmatelib==1.0.15
     # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
-cryptography==3.3.2
+cryptography==38.0.1
     # via
     #   -r requirements/requirements.txt
     #   paramiko
@@ -170,7 +170,7 @@ pyjwt==2.4.0
     #   h-vialib
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
@@ -218,12 +218,10 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   asttokens
     #   bcrypt
-    #   cryptography
     #   dockerpty
     #   jsonschema
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pywb
     #   requests-file

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -39,7 +39,7 @@ checkmatelib==1.0.15
     # via -r requirements/requirements.txt
 click==8.1.3
     # via pip-tools
-cryptography==3.3.2
+cryptography==38.0.1
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
@@ -127,7 +127,7 @@ pyjwt==2.4.0
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pyopenssl==19.1.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
@@ -170,9 +170,7 @@ sentry-sdk==1.9.0
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
-    #   cryptography
     #   jsonschema
-    #   pyopenssl
     #   python-dateutil
     #   pywb
     #   requests-file

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -57,7 +57,7 @@ click==8.1.3
     #   pip-tools
 coverage==6.5.0
     # via -r requirements/tests.txt
-cryptography==3.3.2
+cryptography==38.0.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -194,7 +194,7 @@ pyjwt==2.4.0
     #   h-vialib
 pylint==2.14.5
     # via -r requirements/lint.in
-pyopenssl==19.1.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -251,9 +251,7 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   cryptography
     #   jsonschema
-    #   pyopenssl
     #   python-dateutil
     #   pywb
     #   requests-file

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,7 @@ charset-normalizer==2.0.6
     # via requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.in
-cryptography==3.3.2
+cryptography==38.0.1
     # via pyopenssl
 defusedxml==0.6.0
     # via py3amf
@@ -62,7 +62,7 @@ pycparser==2.20
     # via cffi
 pyjwt==2.4.0
     # via h-vialib
-pyopenssl==19.1.0
+pyopenssl==22.1.0
     # via certauth
 pyrsistent==0.17.3
     # via jsonschema
@@ -88,9 +88,7 @@ sentry-sdk==1.9.0
     # via -r requirements/requirements.in
 six==1.15.0
     # via
-    #   cryptography
     #   jsonschema
-    #   pyopenssl
     #   python-dateutil
     #   pywb
     #   requests-file

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -41,7 +41,7 @@ click==8.1.3
     # via pip-tools
 coverage==6.5.0
     # via -r requirements/tests.in
-cryptography==3.3.2
+cryptography==38.0.1
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
@@ -131,7 +131,7 @@ pyjwt==2.4.0
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-pyopenssl==19.1.0
+pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
@@ -174,9 +174,7 @@ sentry-sdk==1.9.0
 six==1.15.0
     # via
     #   -r requirements/requirements.txt
-    #   cryptography
     #   jsonschema
-    #   pyopenssl
     #   python-dateutil
     #   pywb
     #   requests-file


### PR DESCRIPTION
Upgrade the `cryptography` and `pyopenssl` packages to their latest
versions by running:

    make requirements --always-make args='--upgrade-package cryptography --upgrade-package pyopenssl'

When trying to run Via HTML on a Mac with Apple Silicon it's crashing
when trying to compile the ancient version of `cryptography` that Via
HTML depends on:

    fatal error: 'openssl/opensslv.h' file not found

I think `cryptography` publish pre-compiled binary wheels for Apple
Silicon so `pip` shouldn't need to compile it. I suspect that the old
version of `cryptography` has no Apple Silicon pre-compiled binary so
that's why it's trying to compile it.

Fix this by upgrading `cryptography` to the latest version.

Also upgrade `pyopenssl` at the same time, otherwise the tests fail
because the old version of `pyopenssl` doesn't work with the latest
`cryptography`:

    viahtml/app.py:10: in <module>
        from pywb.apps.frontendapp import FrontEndApp
    .tox/tests/lib/python3.8/site-packages/pywb/apps/frontendapp.py:9: in <module>
        from wsgiprox.wsgiprox import WSGIProxMiddleware
    .tox/tests/lib/python3.8/site-packages/wsgiprox/wsgiprox.py:15: in <module>
        from certauth.certauth import CertificateAuthority
    .tox/tests/lib/python3.8/site-packages/certauth/certauth.py:6: in <module>
        from OpenSSL import crypto
    .tox/tests/lib/python3.8/site-packages/OpenSSL/__init__.py:8: in <module>
        from OpenSSL import crypto, SSL
    .tox/tests/lib/python3.8/site-packages/OpenSSL/crypto.py:1517: in <module>
        class X509StoreFlags(object):
    .tox/tests/lib/python3.8/site-packages/OpenSSL/crypto.py:1537: in X509StoreFlags
        CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
    E   AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

Slack threads:

* https://hypothes-is.slack.com/archives/C1MA4E9B9/p1664885019098739
* https://hypothes-is.slack.com/archives/C4K6M7P5E/p1664808083310179
