### PR TITLE
Tweak deployment job dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
 
   prod-viahtml:
-    needs: [create-image, qa-viahtml]
+    needs: qa-viahtml
     name: ${{ github.event.repository.name }}
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
@@ -65,7 +65,7 @@ jobs:
     secrets: inherit
 
   prod-lms-viahtml:
-    needs: [create-image, qa-lms-viahtml]
+    needs: qa-lms-viahtml
     name: lms-viahtml
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:


### PR DESCRIPTION
I think this might make GitHub Actions's visualisation of the deployment
jobs look better, but I suspect it may actually just break the workflow.
