### PR TITLE
Use better GitHub environment URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA
-      github_environment_url: https://qa-via.hypothes.is/
+      github_environment_url: https://qa-via.hypothes.is/https://en.wikipedia.org/wiki/Diplodocus
       aws_region: us-west-1
       elasticbeanstalk_application: viahtml
       elasticbeanstalk_environment: qa
@@ -43,7 +43,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA (Edu)
-      github_environment_url: https://qa-lms-via.hypothes.is/
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/877
       aws_region: us-west-1
       elasticbeanstalk_application: lms-viahtml
       elasticbeanstalk_environment: qa
@@ -56,7 +56,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production
-      github_environment_url: https://via.hypothes.is/
+      github_environment_url: https://via.hypothes.is/https://en.wikipedia.org/wiki/Diplodocus
       aws_region: us-west-1
       elasticbeanstalk_application: viahtml
       elasticbeanstalk_environment: prod
@@ -70,7 +70,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production (Edu)
-      github_environment_url: https://lms-via.hypothes.is/
+      github_environment_url: https://hypothesis.instructure.com/courses/125/assignments/881
       aws_region: us-west-1
       elasticbeanstalk_application: lms-viahtml
       elasticbeanstalk_environment: prod


### PR DESCRIPTION
For QA and production Via HTML use direct URLs for proxying an HTML
page.

For QA and production Via HTML (Edu) use links to HTML test assignments
from our test Canvas instance. (You can't use Via HTML (Edu) directly,
you have to go through the LMS app.)