### PR TITLE
Prevent pywb from rewriting links with `rel=canonical`

### DIFF
--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -155,6 +155,10 @@ class TestHooks:
                 [("referrerpolicy", "no-referrer-when-downgrade")],
                 False,
             ),
+            # Check we prevent rewriting of Canonical URLs
+            ("link", [("rel", "canonical")], [("rel", "canonical")], True),
+            # And we leave other types of link alone
+            ("link", [("rel", "style")], [("rel", "style")], False),
         ),
     )
     def test_modify_tag_attrs_disables_rewriting(

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -104,6 +104,12 @@ class Hooks:
             )
             stop = True
 
+        # Prevent `pywb` rewriting canonical URLs, as the client + h use them
+        # for document equivalence. We want these to appear the same as they
+        # would if the client visited the URL directly.
+        if tag == "link" and ("rel", "canonical") in attrs:
+            stop = True
+
         attrs = [
             (key, rewrites[key](value) if key in rewrites else value)
             for key, value in attrs


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/lms/issues/4697

We include our own canonical link in the header, but if the document includes one `pywb` was rewriting it to be a link pointing to Via. This caused annotations to get lost.

## Questions

 * Is there any problem with allowing a document to declare it's own Canonical URL?

## Testing notes

 * Start Via and ViaHTML
 * Visit: http://localhost:9083/https://www.ascd.org/el/articles/6-intrinsic-motivators-to-power-up-your-teaching
 * Open dev tools
 * Filter by `openSidebar`
 * Look at the HTML response and search for `canonical`
 * You should see our canonical URL added with `<!-- Set canonical url -->`
 * You should find another one added by the original document

Depending on branch:

 * In `main` - The URL is rewritten to include Via information
 * In this branch - The URL is the original document URL