### PR TITLE
Remove all attributes from canonical links to prevent rewriting

### DIFF
--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -156,7 +156,7 @@ class TestHooks:
                 False,
             ),
             # Check we prevent rewriting of Canonical URLs
-            ("link", [("rel", "canonical")], [("rel", "canonical")], True),
+            ("link", [("rel", "canonical")], [], True),
             # And we leave other types of link alone
             ("link", [("rel", "style")], [("rel", "style")], False),
         ),

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -109,6 +109,10 @@ class Hooks:
         # would if the client visited the URL directly.
         if tag == "link" and ("rel", "canonical") in attrs:
             stop = True
+            # This is a slight desperation measure, as even if the backend
+            # doesn't rewrite this, the front end does, causing trouble. By
+            # removing all attributes there is nothing to rewrite.
+            attrs = []
 
         attrs = [
             (key, rewrites[key](value) if key in rewrites else value)


### PR DESCRIPTION
A possible fix for:

 * https://github.com/hypothesis/viahtml/issues/438

This is a very nuclear option, but should fully suppress canonical links in the original document. This might tide us over until we do something fancier.