### PR TITLE
Copy all static resources from pywb/static/ to Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,12 @@ docker:
 run-docker:
 	@docker run \
 	    -it --rm \
+	    -e "CHECKMATE_API_KEY=dummy-key" \
+	    -e "CHECKMATE_URL=https://qa-checkmate.hypothes.is" \
 	    -e "NEW_RELIC_LICENSE_KEY=$(NEW_RELIC_LICENSE_KEY)" \
 	    -e "NEW_RELIC_ENVIRONMENT=dev" \
 	    -e "NEW_RELIC_APP_NAME=viahtml (dev)" \
+	    -e "VIA_ALLOWED_REFERRERS=localhost:9083" \
 	    -e "VIA_H_EMBED_URL=https://cdn.hypothes.is/hypothesis@qa" \
 	    -e "VIA_IGNORE_PREFIXES=https://qa.hypothes.is/,https://cdn.hypothes.is/" \
 	    -e "VIA_BLOCKLIST_URL=https://hypothesis-via.s3-us-west-1.amazonaws.com/via-blocklist.txt" \

--- a/bin/build_static.py
+++ b/bin/build_static.py
@@ -1,38 +1,9 @@
 """Copy all required static content out of `pywb` so NGINX can serve it."""
 import os
 import os.path
-from shutil import copyfile, rmtree
+from shutil import copytree, rmtree
 
 import importlib_resources
-
-# All the pywb resources we know we need
-MANIFEST = (
-    "autoFetchWorker.js",
-    "default_banner.js",
-    "flowplayer/toolbox.flashembed.js",
-    "js/bootstrap.min.js",
-    "js/jquery-latest.min.js",
-    "js/url-polyfill.min.js",
-    "query.js",
-    "queryWorker.js",
-    "search.js",
-    "transclusions.js",
-    "vidrw.js",
-    "wb_frame.js",
-    "wombat.js",
-    "wombatProxyMode.js",
-    "wombatWorkers.js",
-)
-
-
-def _copy(source_file, target_file):
-    print(f"{source_file} >>> {target_file}")
-
-    dir_name = os.path.dirname(target_file)
-    if not os.path.exists(dir_name):
-        os.makedirs(dir_name)
-
-    copyfile(source_file, target_file)
 
 
 def _create_static(source, target):
@@ -40,14 +11,8 @@ def _create_static(source, target):
         print(f"Removing old static directory: {target}")
         rmtree(target)
 
-    print(f"Copying `pywb` static content: {source}")
-    for path in MANIFEST:
-        source_file, target_file = os.path.join(source, path), os.path.join(
-            target, path
-        )
-        _copy(source_file, target_file)
-
-    print(f"Created: {target}")
+    print(f"Copying `pywb` static content: {source} to {target}")
+    copytree(source, target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Copy all resources instead of a specific list of files.

This fixes an issue where Docker builds failed after the latest pywb 2.6.7 => 2.7.3 upgrade due to one of the files no longer being present in the pywb package. More generally this makes pywb version upgrades easier by not requiring this script to be updated as often when updating pywb versions, at the cost of also including some files we don't actually need.

On a related note, it seems that CI builds don't verify that Docker builds work. This will be fixed separately.

To verify:

1. Check out this branch
2. Run `make docker`
3. Run `docker create docker.io/hypothesis/viahtml:dev` to create a container but not start it. This will print out a container ID.
4. Run `docker export <container ID> > viahtml.tar` to export container filesystem to tarball
5. Run `tar -tf viahtml.tar` to list the contents of the filesystem

You should see the files from pywb in locations under `/var/lib/hypothesis/static/static/pywb/` - the double `/static/` here looks odd, but I verified that it matches the layout from before the change.

Before (commit 1632192):

<details>

```
var/lib/hypothesis/static/
var/lib/hypothesis/static/static/
var/lib/hypothesis/static/static/img/
var/lib/hypothesis/static/static/img/favicon.ico
var/lib/hypothesis/static/static/pywb/
var/lib/hypothesis/static/static/pywb/autoFetchWorker.js
var/lib/hypothesis/static/static/pywb/autoFetchWorker.js.gz
var/lib/hypothesis/static/static/pywb/default_banner.js
var/lib/hypothesis/static/static/pywb/default_banner.js.gz
var/lib/hypothesis/static/static/pywb/flowplayer/
var/lib/hypothesis/static/static/pywb/flowplayer/toolbox.flashembed.js
var/lib/hypothesis/static/static/pywb/flowplayer/toolbox.flashembed.js.gz
var/lib/hypothesis/static/static/pywb/js/
var/lib/hypothesis/static/static/pywb/js/bootstrap.min.js
var/lib/hypothesis/static/static/pywb/js/bootstrap.min.js.gz
var/lib/hypothesis/static/static/pywb/js/jquery-latest.min.js
var/lib/hypothesis/static/static/pywb/js/jquery-latest.min.js.gz
var/lib/hypothesis/static/static/pywb/js/url-polyfill.min.js
var/lib/hypothesis/static/static/pywb/js/url-polyfill.min.js.gz
var/lib/hypothesis/static/static/pywb/query.js
var/lib/hypothesis/static/static/pywb/query.js.gz
var/lib/hypothesis/static/static/pywb/queryWorker.js
var/lib/hypothesis/static/static/pywb/queryWorker.js.gz
var/lib/hypothesis/static/static/pywb/search.js
var/lib/hypothesis/static/static/pywb/search.js.gz
var/lib/hypothesis/static/static/pywb/transclusions.js
var/lib/hypothesis/static/static/pywb/transclusions.js.gz
var/lib/hypothesis/static/static/pywb/vidrw.js
var/lib/hypothesis/static/static/pywb/vidrw.js.gz
var/lib/hypothesis/static/static/pywb/wb_frame.js
var/lib/hypothesis/static/static/pywb/wb_frame.js.gz
var/lib/hypothesis/static/static/pywb/wombat.js
var/lib/hypothesis/static/static/pywb/wombat.js.gz
var/lib/hypothesis/static/static/pywb/wombatProxyMode.js
var/lib/hypothesis/static/static/pywb/wombatProxyMode.js.gz
var/lib/hypothesis/static/static/pywb/wombatWorkers.js
var/lib/hypothesis/static/static/pywb/wombatWorkers.js.gz
```

</details>

After:

<details>

```
var/lib/hypothesis/static/static/
var/lib/hypothesis/static/static/img/
var/lib/hypothesis/static/static/img/favicon.ico
var/lib/hypothesis/static/static/pywb/
var/lib/hypothesis/static/static/pywb/autoFetchWorker.js
var/lib/hypothesis/static/static/pywb/autoFetchWorker.js.gz
var/lib/hypothesis/static/static/pywb/calendar-icon.png
var/lib/hypothesis/static/static/pywb/calendar.svg
var/lib/hypothesis/static/static/pywb/calendar.svg.gz
var/lib/hypothesis/static/static/pywb/css/
var/lib/hypothesis/static/static/pywb/css/base.css
var/lib/hypothesis/static/static/pywb/css/base.css.gz
var/lib/hypothesis/static/static/pywb/css/bootstrap.min.css
var/lib/hypothesis/static/static/pywb/css/bootstrap.min.css.gz
var/lib/hypothesis/static/static/pywb/css/font-awesome.min.css
var/lib/hypothesis/static/static/pywb/css/font-awesome.min.css.gz
var/lib/hypothesis/static/static/pywb/css/query.css
var/lib/hypothesis/static/static/pywb/css/query.css.gz
var/lib/hypothesis/static/static/pywb/flowplayer/
var/lib/hypothesis/static/static/pywb/flowplayer/flowplayer-3.2.18.swf
var/lib/hypothesis/static/static/pywb/flowplayer/flowplayer.audio-3.2.11.swf
var/lib/hypothesis/static/static/pywb/flowplayer/flowplayer.controls-3.2.16.swf
var/lib/hypothesis/static/static/pywb/flowplayer/flowplayer.pseudostreaming-3.2.13.swf
var/lib/hypothesis/static/static/pywb/flowplayer/toolbox.flashembed.js
var/lib/hypothesis/static/static/pywb/flowplayer/toolbox.flashembed.js.gz
var/lib/hypothesis/static/static/pywb/fonts/
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.eot
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.eot.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.svg
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.svg.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.ttf
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.ttf.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.woff
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-brands-400.woff2
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.eot
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.eot.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.svg
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.svg.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.ttf
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.ttf.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.woff
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-regular-400.woff2
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.eot
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.eot.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.svg
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.svg.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.ttf
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.ttf.gz
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.woff
var/lib/hypothesis/static/static/pywb/fonts/font-awesome/fa-solid-900.woff2
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.eot
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.svg
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.svg.gz
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.ttf
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.ttf.gz
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.woff
var/lib/hypothesis/static/static/pywb/fonts/glyphicons-halflings-regular.woff2
var/lib/hypothesis/static/static/pywb/js/
var/lib/hypothesis/static/static/pywb/js/bootstrap.min.js
var/lib/hypothesis/static/static/pywb/js/bootstrap.min.js.gz
var/lib/hypothesis/static/static/pywb/js/jquery-latest.min.js
var/lib/hypothesis/static/static/pywb/js/jquery-latest.min.js.gz
var/lib/hypothesis/static/static/pywb/js/url-polyfill.min.js
var/lib/hypothesis/static/static/pywb/js/url-polyfill.min.js.gz
var/lib/hypothesis/static/static/pywb/loading-spinner/
var/lib/hypothesis/static/static/pywb/loading-spinner/loading-spinner.js
var/lib/hypothesis/static/static/pywb/loading-spinner/loading-spinner.js.gz
var/lib/hypothesis/static/static/pywb/loading-spinner/test.html
var/lib/hypothesis/static/static/pywb/loading-spinner/test.html.gz
var/lib/hypothesis/static/static/pywb/pywb-logo-sm.png
var/lib/hypothesis/static/static/pywb/pywb-logo.png
var/lib/hypothesis/static/static/pywb/query.js
var/lib/hypothesis/static/static/pywb/query.js.gz
var/lib/hypothesis/static/static/pywb/queryWorker.js
var/lib/hypothesis/static/static/pywb/queryWorker.js.gz
var/lib/hypothesis/static/static/pywb/scroll-webkit.css
var/lib/hypothesis/static/static/pywb/scroll-webkit.css.gz
var/lib/hypothesis/static/static/pywb/search.js
var/lib/hypothesis/static/static/pywb/search.js.gz
var/lib/hypothesis/static/static/pywb/timeline-icon.png
var/lib/hypothesis/static/static/pywb/transclusions.js
var/lib/hypothesis/static/static/pywb/transclusions.js.gz
var/lib/hypothesis/static/static/pywb/vidrw.js
var/lib/hypothesis/static/static/pywb/vidrw.js.gz
var/lib/hypothesis/static/static/pywb/vue/
var/lib/hypothesis/static/static/pywb/vue/vueui.js
var/lib/hypothesis/static/static/pywb/vue/vueui.js.gz
var/lib/hypothesis/static/static/pywb/vue_banner.css
var/lib/hypothesis/static/static/pywb/wb_frame.js
var/lib/hypothesis/static/static/pywb/wb_frame.js.gz
var/lib/hypothesis/static/static/pywb/wombat.js
var/lib/hypothesis/static/static/pywb/wombat.js.gz
var/lib/hypothesis/static/static/pywb/wombatProxyMode.js
var/lib/hypothesis/static/static/pywb/wombatProxyMode.js.gz
var/lib/hypothesis/static/static/pywb/wombatWorkers.js
var/lib/hypothesis/static/static/pywb/wombatWorkers.js.gz
var/lib/hypothesis/static/static/pywb/zoom-out-icon-333316.png
```

</details>

I have also fixed up `make run-docker` so you can use that to start viahtml in a container locally and then test that static resources are served as expected.