### PR TITLE
Allow hint in iframe to bypass proxy

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -53,6 +53,8 @@ def upstream_website():
        <body>
          <!-- upstream content -->
          <a href="http://example.com">link</a>
+         <iframe id="proxy-iframe" src="http://example.com"></iframe>
+         <iframe id="no-proxy-iframe" src="http://example.com" data-viahtml-no-proxy></iframe>
        </body>
      </html>
      """

--- a/tests/functional/proxy_test.py
+++ b/tests/functional/proxy_test.py
@@ -35,6 +35,17 @@ class TestProxy:
     def test_we_dont_rewrite_links_by_default(self, proxied_content):
         assert '<a href="http://example.com">link</a>' in proxied_content
 
+    def test_we_proxy_iframe_by_default(self, proxied_content):
+        assert '<iframe id="proxy-iframe" src="http://localhost' in proxied_content
+
+    def test_we_do_not_proxy_iframe_when_data_viahtml_no_proxy_is_set(
+        self, proxied_content
+    ):
+        assert (
+            '<iframe id="no-proxy-iframe" src="http://example.com" data-viahtml-no-proxy></iframe>'
+            in proxied_content
+        )
+
     @pytest.mark.parametrize(
         "link_mode,expected",
         (

--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -159,6 +159,14 @@ class TestHooks:
             ("link", [("rel", "canonical")], [("rel", "canonical")], True),
             # And we leave other types of link alone
             ("link", [("rel", "style")], [("rel", "style")], False),
+            # Check for attributes that disable proxying of iframes
+            (
+                "iframe",
+                [("data-viahtml-no-proxy", None)],
+                [("data-viahtml-no-proxy", None)],
+                True,
+            ),
+            ("iframe", [], [], False),
         ),
     )
     def test_modify_tag_attrs_disables_rewriting(

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ filterwarnings =
     ignore:invalid escape sequence
     ; Mostly from importing pywb.apps.frontendapp.FrontEndApp
     ignore:Monkey-patching ssl after ssl has already been imported may lead to errors.*:gevent.monkey.MonkeyPatchWarning:
+    ; pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
+    ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
 
 xfail_strict=true
 

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -110,6 +110,10 @@ class Hooks:
         if tag == "link" and ("rel", "canonical") in attrs:
             stop = True
 
+        ## Allow iframes to hint to Via to not proxy
+        if tag == "iframe" and ("data-viahtml-no-proxy", None) in attrs:
+            stop = True
+
         attrs = [
             (key, rewrites[key](value) if key in rewrites else value)
             for key, value in attrs


### PR DESCRIPTION
Allow a page to have iframes that remain unproxied when the data-h-no-proxy attribute is set.

Resolves hypothesis/viahtml#457