### PR TITLE
Add a filter warning for pkg_resources deprecation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ filterwarnings =
     ignore:Monkey-patching ssl after ssl has already been imported may lead to errors.*:gevent.monkey.MonkeyPatchWarning:
     ; pkg_resources is calling its own deprecated function? Anyway I don't think the problem is with us.
     ignore:^Deprecated call to .pkg_resources\.declare_namespace\('.*'\).\.:DeprecationWarning:pkg_resources
+    ; pkg_resources used in some of our dependencies
+    ignore:^pkg_resources is deprecated as an API$:DeprecationWarning:pkg_resources
+
 
 xfail_strict=true
 


### PR DESCRIPTION
Some of our dependencies use the deprecated pkg_resources API.

Ignoring the warning until they get updated.