### PR TITLE
Revert "Bump certifi from 2022.12.7 to 2023.7.22"

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -18,7 +18,7 @@ certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   -r requirements/requirements.txt
     #   requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,7 @@ certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   -r requirements/requirements.txt
     #   requests

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -20,7 +20,7 @@ certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   -r requirements/requirements.txt
     #   requests

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -29,7 +29,7 @@ certauth==1.3.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ brotlipy==0.7.0
     # via pywb
 certauth==1.3.0
     # via wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   requests
     #   sentry-sdk

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -20,7 +20,7 @@ certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2022.12.7
     # via
     #   -r requirements/requirements.txt
     #   requests


### PR DESCRIPTION
This reverts commit 3d2d08d714a63f3622406607b55a85569f5b09f2.

New version of Cpython make pyyaml to fail to build but the version we use is pinned by docker-compose v1 which is itself deprecated and won't be updated.

https://github.com/yaml/pyyaml/issues/601
https://github.com/docker/compose/issues/10836

Reverting this to have a deployable version on main.