### PR TITLE
Remove docker-compose dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ run-docker:
 
 .PHONY: nginx
 nginx: python
-	@tox -qe dev --run-command 'docker-compose run --rm --service-ports nginx-proxy'
+	@docker compose run --rm --service-ports nginx-proxy
 
 .PHONY: web
 web:

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -5,7 +5,7 @@ environment=PYTHONUNBUFFERED="1"
 # logfile_maxbytes=0
 
 [program:nginx]
-command=docker-compose run --rm --service-ports nginx-proxy
+command=docker compose run --rm --service-ports nginx-proxy
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = INT

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,5 +4,4 @@ pip-tools
 pip-sync-faster
 ipython
 ipdb
-docker-compose
 supervisor

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,8 +12,6 @@ attrs==20.3.0
     #   jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==3.2.0
-    # via paramiko
 brotlipy==0.7.0
     # via
     #   -r requirements/requirements.txt
@@ -32,10 +30,8 @@ certifi==2022.12.7
 cffi==1.14.2
     # via
     #   -r requirements/requirements.txt
-    #   bcrypt
     #   brotlipy
     #   cryptography
-    #   pynacl
 charset-normalizer==2.0.6
     # via
     #   -r requirements/requirements.txt
@@ -47,7 +43,6 @@ click==8.1.3
 cryptography==38.0.3
     # via
     #   -r requirements/requirements.txt
-    #   paramiko
     #   pyopenssl
     #   python-jose
 decorator==5.0.7
@@ -58,16 +53,6 @@ defusedxml==0.6.0
     # via
     #   -r requirements/requirements.txt
     #   py3amf
-distro==1.5.0
-    # via docker-compose
-docker[ssh]==5.0.0
-    # via docker-compose
-docker-compose==1.29.2
-    # via -r requirements/dev.in
-dockerpty==0.4.1
-    # via docker-compose
-docopt==0.6.2
-    # via docker-compose
 ecdsa==0.18.0
     # via
     #   -r requirements/requirements.txt
@@ -120,7 +105,6 @@ jsonschema==3.2.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-    #   docker-compose
 markupsafe==1.1.1
     # via
     #   -r requirements/requirements.txt
@@ -136,8 +120,6 @@ newrelic==8.8.1
     # via -r requirements/requirements.txt
 packaging==21.3
     # via build
-paramiko==2.10.1
-    # via docker
 parso==0.8.2
     # via jedi
 pep517==0.13.0
@@ -177,8 +159,6 @@ pycparser==2.20
     #   cffi
 pygments==2.15.0
     # via ipython
-pynacl==1.4.0
-    # via paramiko
 pyopenssl==22.1.0
     # via
     #   -r requirements/requirements.txt
@@ -193,8 +173,6 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-python-dotenv==0.17.0
-    # via docker-compose
 python-jose[cryptography]==3.3.0
     # via
     #   -r requirements/requirements.txt
@@ -204,7 +182,6 @@ pywb==2.7.4
 pyyaml==5.4
     # via
     #   -r requirements/requirements.txt
-    #   docker-compose
     #   pywb
 redis==2.10.6
     # via
@@ -215,8 +192,6 @@ requests==2.31.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-    #   docker
-    #   docker-compose
     #   pywb
     #   requests-file
     #   tldextract
@@ -234,18 +209,13 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   asttokens
-    #   bcrypt
-    #   dockerpty
     #   ecdsa
     #   jsonschema
-    #   paramiko
-    #   pynacl
     #   python-dateutil
     #   pywb
     #   requests-file
     #   surt
     #   warcio
-    #   websocket-client
     #   wsgiprox
 stack-data==0.1.4
     # via ipython
@@ -255,8 +225,6 @@ surt==0.3.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-texttable==1.6.3
-    # via docker-compose
 tldextract==2.2.3
     # via
     #   -r requirements/requirements.txt
@@ -304,10 +272,6 @@ webob==1.8.6
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
-websocket-client==0.58.0
-    # via
-    #   docker
-    #   docker-compose
 werkzeug==1.0.1
     # via
     #   -r requirements/requirements.txt


### PR DESCRIPTION
Rely instead on the go version of docker (which now includes composer).

The python version of docker-compose is no longer supported and it has pinned dependencies to old packages that are holding back security upgrades of other packages.



## Testing

Just try `make dev` on local