### PR TITLE
Disable proxying for several popular embedded video players

### DIFF
--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -7,6 +7,7 @@ from warcio.statusandheaders import StatusAndHeaders
 
 from viahtml.context import Context
 from viahtml.hooks import Hooks
+from viahtml.hooks.hooks import MEDIA_EMBED_PREFIXES
 
 
 class TestHooks:
@@ -46,8 +47,8 @@ class TestHooks:
 
         assert external_link_mode(http_env) == expected
 
-    def test_ignore_prefixes(self, hooks):
-        assert hooks.ignore_prefixes == sentinel.prefixes
+    def test_ignore_prefixes(self, hooks, ignore_prefixes):
+        assert hooks.ignore_prefixes == ignore_prefixes + MEDIA_EMBED_PREFIXES
 
     def test_get_config(self, Configuration, hooks):
         config = hooks.get_config(sentinel.http_env)
@@ -203,12 +204,12 @@ class TestHooks:
         return context
 
     @pytest.fixture
-    def hooks(self, context):
+    def hooks(self, context, ignore_prefixes):
         hooks = Hooks(
             {
                 "config_noise": "noise",
                 "h_embed_url": sentinel.h_embed_url,
-                "ignore_prefixes": sentinel.prefixes,
+                "ignore_prefixes": ignore_prefixes,
                 "rewrite": {"a_href": True},
             }
         )
@@ -216,6 +217,10 @@ class TestHooks:
         hooks.set_context(context)
 
         return hooks
+
+    @pytest.fixture
+    def ignore_prefixes(self):
+        return ["https://hypothes.is", "https://dontproxy.me"]
 
     @pytest.fixture
     def Configuration(self):

--- a/viahtml/hooks/hooks.py
+++ b/viahtml/hooks/hooks.py
@@ -3,6 +3,19 @@ from h_vialib import Configuration
 
 from viahtml.hooks._headers import Headers
 
+# Prefixes of media player embeds (iframes) that we want to avoid proxying or
+# blocking.
+#
+# Proxying this content is resource intensive, but we don't want to block it
+# either. See https://github.com/hypothesis/support/issues/28.
+MEDIA_EMBED_PREFIXES = [
+    # Example: https://kaltura.github.io/EmbedCodeGenerator/demo/
+    "https://cdnapisec.kaltura.com/",
+    # See https://help.vimeo.com/hc/en-us/articles/12426259908881-How-do-I-embed-my-video-
+    "https://player.vimeo.com/",
+    "https://www.youtube.com/embed/",
+]
+
 
 class Hooks:
     """A collection of configuration points for `pywb`."""
@@ -38,7 +51,7 @@ class Hooks:
     def ignore_prefixes(self):
         """Get the list of URL prefixes to ignore (server and client side)."""
 
-        return self.config["ignore_prefixes"]
+        return self.config["ignore_prefixes"] + MEDIA_EMBED_PREFIXES
 
     @classmethod
     def get_config(cls, http_env):


### PR DESCRIPTION
YouTube was originally blocked in Via because proxying the video content is resource intensive, and people were using Via as a way of getting around content blocking at work/school etc. However we don't want to really want to block this content when it appears as an embed, we just want to avoid proxying it.

This commit adds the prefixes of several popular embedded video players to the existing allowlist that we use to prevent Via from proxying the Hypothesis client's iframe/scripts/styles. A downside of this approach is that we have to individually add new video players as we encounter them. A broader approach might be to try and avoid proxying iframes altogether, but that is a riskier change.

An alternative approach would be to make the policy of whether to proxy or not part of checkmate. For example we could make it so that proxied iframes redirect to the original URL, rather than being blocked, if the reason for blocking is video content. I'd need to verify that we can tell whether proxied content is being proxied at the top level or an iframe.

Part of https://github.com/hypothesis/support/issues/28

---

**Testing:**

Try visiting these pages through Via. On this branch, the video embeds should work and they should not be proxied - the player iframe's `src` should be the original URL.

https://mlpp.pressbooks.pub/publicspeakingresouceproject/chapter/introduction/
https://kaltura.github.io/EmbedCodeGenerator/demo/