### PR TITLE
Upgrade python dependencies

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,44 +4,45 @@
 #
 #    pip-compile --allow-unsafe requirements/build.in
 #
-attrs==20.3.0
+attrs==23.2.0
     # via
     #   -r requirements/requirements.txt
     #   jsonschema
+    #   referencing
 brotlipy==0.7.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-build==0.8.0
+build==1.0.3
     # via pip-tools
 certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via
     #   -r requirements/requirements.txt
     #   requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.txt
-click==8.1.3
+click==8.1.7
     # via pip-tools
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
     #   python-jose
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/requirements.txt
     #   py3amf
@@ -53,52 +54,61 @@ fakeredis==0.16.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
+filelock==3.13.1
+    # via
+    #   -r requirements/requirements.txt
+    #   tldextract
 gevent==21.12.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via
     #   -r requirements/requirements.txt
     #   gevent
 h-vialib==1.2.1
     # via -r requirements/requirements.txt
-idna==2.10
+idna==3.6
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   h-vialib
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
+    #   jsonschema
+    #   jsonschema-specifications
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+markupsafe==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
-netaddr==0.8.0
+netaddr==0.10.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via -r requirements/requirements.txt
-packaging==21.3
-    # via build
-pep517==0.13.0
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/build.in
@@ -106,33 +116,33 @@ pip-tools==7.3.0
     # via
     #   -r requirements/build.in
     #   pip-sync-faster
-portalocker==2.0.0
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+portalocker==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-py3amf==0.8.10
+py3amf==0.8.11
     # via
     #   -r requirements/requirements.txt
     #   pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/requirements.txt
     #   cffi
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
-pyparsing==3.0.9
-    # via packaging
-pyrsistent==0.17.3
-    # via
-    #   -r requirements/requirements.txt
-    #   jsonschema
+pyproject-hooks==1.0.0
+    # via build
 python-dateutil==2.8.2
     # via
     #   -r requirements/requirements.txt
@@ -153,6 +163,11 @@ redis==2.10.6
     #   -r requirements/requirements.txt
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/requirements.txt
@@ -164,17 +179,21 @@ requests-file==1.5.1
     # via
     #   -r requirements/requirements.txt
     #   tldextract
+rpds-py==0.16.2
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via -r requirements/requirements.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
@@ -185,7 +204,7 @@ surt==0.3.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   -r requirements/requirements.txt
     #   certauth
@@ -194,9 +213,9 @@ tldextract==2.2.3
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
-ua-parser==0.10.0
+    #   pyproject-hooks
+ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
@@ -219,7 +238,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
@@ -227,7 +246,7 @@ werkzeug==2.1.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0
     # via
@@ -237,28 +256,27 @@ wsgiprox==1.5.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/requirements.txt
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via
     #   -r requirements/requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   -r requirements/requirements.txt
     #   gevent
-    #   jsonschema
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -6,49 +6,51 @@
 #
 black==23.12.1
     # via -r requirements/checkformatting.in
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==5.0.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 isort==5.13.2
     # via -r requirements/checkformatting.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/checkformatting.in
 pip-tools==7.3.0
     # via
     #   -r requirements/checkformatting.in
     #   pip-sync-faster
-platformdirs==2.5.2
+platformdirs==4.1.0
     # via black
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
-typing-extensions==4.3.0
+    #   pyproject-hooks
+typing-extensions==4.9.0
     # via black
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --allow-unsafe requirements/coverage.in
 #
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
 coverage==7.4.0
     # via -r requirements/coverage.in
-importlib-metadata==5.0.0
-    # via pip-sync-faster
-packaging==21.3
-    # via build
-pep517==0.13.0
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/coverage.in
@@ -22,20 +22,20 @@ pip-tools==7.3.0
     # via
     #   -r requirements/coverage.in
     #   pip-sync-faster
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
-wheel==0.38.1
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,52 +4,53 @@
 #
 #    pip-compile --allow-unsafe requirements/dev.in
 #
-asttokens==2.0.5
+asttokens==2.4.1
     # via stack-data
-attrs==20.3.0
+attrs==23.2.0
     # via
     #   -r requirements/requirements.txt
     #   jsonschema
+    #   referencing
 backcall==0.2.0
     # via ipython
 brotlipy==0.7.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-build==0.8.0
+build==1.0.3
     # via pip-tools
 certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via
     #   -r requirements/requirements.txt
     #   requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.txt
-click==8.1.3
+click==8.1.7
     # via pip-tools
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
     #   python-jose
-decorator==5.0.7
+decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/requirements.txt
     #   py3amf
@@ -57,74 +58,81 @@ ecdsa==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-executing==0.8.2
+executing==2.0.1
     # via stack-data
 fakeredis==0.16.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
+filelock==3.13.1
+    # via
+    #   -r requirements/requirements.txt
+    #   tldextract
 gevent==21.12.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via
     #   -r requirements/requirements.txt
     #   gevent
 h-vialib==1.2.1
     # via -r requirements/requirements.txt
-idna==2.10
+idna==3.6
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   h-vialib
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
+    #   jsonschema
+    #   jsonschema-specifications
 ipdb==0.13.13
     # via -r requirements/dev.in
 ipython==8.12.3
     # via
     #   -r requirements/dev.in
     #   ipdb
-ipython-genutils==0.2.0
-    # via traitlets
-jedi==0.18.0
+jedi==0.19.1
     # via ipython
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+markupsafe==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
-matplotlib-inline==0.1.2
+matplotlib-inline==0.1.6
     # via ipython
-netaddr==0.8.0
+netaddr==0.10.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via -r requirements/requirements.txt
-packaging==21.3
+packaging==23.2
     # via build
-parso==0.8.2
+parso==0.8.3
     # via jedi
-pep517==0.13.0
-    # via build
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
@@ -134,41 +142,41 @@ pip-tools==7.3.0
     # via
     #   -r requirements/dev.in
     #   pip-sync-faster
-portalocker==2.0.0
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+portalocker==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-prompt-toolkit==3.0.36
+prompt-toolkit==3.0.43
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.1
+pure-eval==0.2.2
     # via stack-data
-py3amf==0.8.10
+py3amf==0.8.11
     # via
     #   -r requirements/requirements.txt
     #   pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/requirements.txt
     #   cffi
-pygments==2.15.0
+pygments==2.17.2
     # via ipython
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
-pyparsing==3.0.9
-    # via packaging
-pyrsistent==0.17.3
-    # via
-    #   -r requirements/requirements.txt
-    #   jsonschema
+pyproject-hooks==1.0.0
+    # via build
 python-dateutil==2.8.2
     # via
     #   -r requirements/requirements.txt
@@ -189,6 +197,11 @@ redis==2.10.6
     #   -r requirements/requirements.txt
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/requirements.txt
@@ -200,25 +213,29 @@ requests-file==1.5.1
     # via
     #   -r requirements/requirements.txt
     #   tldextract
+rpds-py==0.16.2
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via -r requirements/requirements.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   asttokens
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
     #   surt
     #   warcio
     #   wsgiprox
-stack-data==0.1.4
+stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
     # via -r requirements/dev.in
@@ -226,7 +243,7 @@ surt==0.3.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   -r requirements/requirements.txt
     #   certauth
@@ -236,15 +253,15 @@ tomli==2.0.1
     # via
     #   build
     #   ipdb
-    #   pep517
     #   pip-tools
-traitlets==5.0.5
+    #   pyproject-hooks
+traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.5.0
+typing-extensions==4.9.0
     # via ipython
-ua-parser==0.10.0
+ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
@@ -259,7 +276,7 @@ warcio==1.7.4
     # via
     #   -r requirements/requirements.txt
     #   pywb
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via prompt-toolkit
 webassets==2.0
     # via
@@ -269,7 +286,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
@@ -277,7 +294,7 @@ werkzeug==2.1.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0
     # via -r requirements/requirements.txt
@@ -285,28 +302,27 @@ wsgiprox==1.5.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/requirements.txt
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via
     #   -r requirements/requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   -r requirements/requirements.txt
     #   gevent
-    #   jsonschema
     #   pip-tools
     #   supervisor
     #   zope-event

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,49 +6,51 @@
 #
 black==23.12.1
     # via -r requirements/format.in
-build==0.8.0
+build==1.0.3
     # via pip-tools
-click==8.0.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==5.0.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 isort==5.13.2
     # via -r requirements/format.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/format.in
 pip-tools==7.3.0
     # via
     #   -r requirements/format.in
     #   pip-sync-faster
-platformdirs==2.2.0
+platformdirs==4.1.0
     # via black
-tomli==2.0.0
+pyproject-hooks==1.0.0
+    # via build
+tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
-typing-extensions==4.7.1
+    #   pyproject-hooks
+typing-extensions==4.9.0
     # via black
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
-zipp==3.8.1
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -4,46 +4,47 @@
 #
 #    pip-compile --allow-unsafe requirements/functests.in
 #
-attrs==20.3.0
+attrs==23.2.0
     # via
     #   -r requirements/requirements.txt
     #   jsonschema
-beautifulsoup4==4.9.3
+    #   referencing
+beautifulsoup4==4.12.2
     # via webtest
 brotlipy==0.7.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-build==0.8.0
+build==1.0.3
     # via pip-tools
 certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via
     #   -r requirements/requirements.txt
     #   requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.txt
-click==8.1.3
+click==8.1.7
     # via pip-tools
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
     #   python-jose
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/requirements.txt
     #   py3amf
@@ -51,17 +52,21 @@ ecdsa==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-exceptiongroup==1.0.0
+exceptiongroup==1.2.0
     # via pytest
 fakeredis==0.16.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
+filelock==3.13.1
+    # via
+    #   -r requirements/requirements.txt
+    #   tldextract
 gevent==21.12.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via
     #   -r requirements/requirements.txt
     #   gevent
@@ -69,82 +74,87 @@ h-vialib==1.2.1
     # via -r requirements/requirements.txt
 httpretty==1.1.4
     # via -r requirements/functests.in
-idna==2.10
+idna==3.6
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   h-vialib
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-iniconfig==1.1.1
+    #   jsonschema
+    #   jsonschema-specifications
+iniconfig==2.0.0
     # via pytest
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+markupsafe==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
-netaddr==0.8.0
+netaddr==0.10.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via -r requirements/requirements.txt
-packaging==20.9
+packaging==23.2
     # via
     #   build
     #   pytest
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/functests.in
 pip-tools==7.3.0
     # via
     #   -r requirements/functests.in
     #   pip-sync-faster
-pluggy==0.13.1
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+pluggy==1.3.0
     # via pytest
-portalocker==2.0.0
+portalocker==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-py3amf==0.8.10
+py3amf==0.8.11
     # via
     #   -r requirements/requirements.txt
     #   pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/requirements.txt
     #   cffi
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
-pyparsing==2.4.7
-    # via packaging
-pyrsistent==0.17.3
-    # via
-    #   -r requirements/requirements.txt
-    #   jsonschema
+pyproject-hooks==1.0.0
+    # via build
 pytest==7.4.4
     # via -r requirements/functests.in
 python-dateutil==2.8.2
@@ -167,6 +177,11 @@ redis==2.10.6
     #   -r requirements/requirements.txt
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/requirements.txt
@@ -178,42 +193,46 @@ requests-file==1.5.1
     # via
     #   -r requirements/requirements.txt
     #   tldextract
+rpds-py==0.16.2
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via -r requirements/requirements.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
     #   surt
     #   warcio
     #   wsgiprox
-soupsieve==2.2
+soupsieve==2.5
     # via beautifulsoup4
 surt==0.3.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   -r requirements/requirements.txt
     #   certauth
     #   pywb
     #   surt
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-ua-parser==0.10.0
+ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
@@ -238,7 +257,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
@@ -249,7 +268,7 @@ werkzeug==2.1.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0
     # via -r requirements/requirements.txt
@@ -257,28 +276,27 @@ wsgiprox==1.5.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/requirements.txt
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via
     #   -r requirements/requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   -r requirements/requirements.txt
     #   gevent
-    #   jsonschema
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,14 +4,15 @@
 #
 #    pip-compile --allow-unsafe requirements/lint.in
 #
-astroid==3.0.1
+astroid==3.0.2
     # via pylint
-attrs==20.3.0
+attrs==23.2.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   jsonschema
-beautifulsoup4==4.9.3
+    #   referencing
+beautifulsoup4==4.12.2
     # via
     #   -r requirements/tests.txt
     #   webtest
@@ -20,7 +21,7 @@ brotlipy==0.7.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-build==0.8.0
+build==1.0.3
     # via
     #   -r requirements/tests.txt
     #   pip-tools
@@ -29,19 +30,19 @@ certauth==1.3.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -50,31 +51,31 @@ checkmatelib==1.0.15
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/tests.txt
     #   pip-tools
 coverage==7.4.0
     # via -r requirements/tests.txt
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pyopenssl
     #   python-jose
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   py3amf
-dill==0.3.4
+dill==0.3.7
     # via pylint
 ecdsa==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   python-jose
-exceptiongroup==1.0.0
+exceptiongroup==1.2.0
     # via
     #   -r requirements/tests.txt
     #   pytest
@@ -83,12 +84,17 @@ fakeredis==0.16.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
+filelock==3.13.1
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   tldextract
 gevent==21.12.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -101,16 +107,17 @@ h-vialib==1.2.1
     #   -r requirements/tests.txt
 httpretty==1.1.4
     # via -r requirements/tests.txt
-idna==2.10
+idna==3.6
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
+    #   build
     #   h-vialib
     #   pip-sync-faster
 importlib-resources==6.1.1
@@ -118,7 +125,9 @@ importlib-resources==6.1.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   checkmatelib
-iniconfig==1.1.1
+    #   jsonschema
+    #   jsonschema-specifications
+iniconfig==2.0.0
     # via
     #   -r requirements/tests.txt
     #   pytest
@@ -129,37 +138,38 @@ jinja2==2.11.3
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   jsonschema
+markupsafe==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   jinja2
     #   pywb
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
-netaddr==0.8.0
+netaddr==0.10.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-packaging==20.9
+packaging==23.2
     # via
     #   -r requirements/tests.txt
     #   build
     #   pytest
-pep517==0.13.0
-    # via
-    #   -r requirements/tests.txt
-    #   build
 pip-sync-faster==0.0.3
     # via
     #   -r requirements/lint.in
@@ -169,29 +179,34 @@ pip-tools==7.3.0
     #   -r requirements/lint.in
     #   -r requirements/tests.txt
     #   pip-sync-faster
-platformdirs==2.2.0
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   jsonschema
+platformdirs==4.1.0
     # via pylint
-pluggy==0.13.1
+pluggy==1.3.0
     # via
     #   -r requirements/tests.txt
     #   pytest
-portalocker==2.0.0
+portalocker==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-py3amf==0.8.10
+py3amf==0.8.11
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -200,20 +215,15 @@ pydocstyle==6.3.0
     # via -r requirements/lint.in
 pylint==3.0.3
     # via -r requirements/lint.in
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   certauth
-pyparsing==2.4.7
+pyproject-hooks==1.0.0
     # via
     #   -r requirements/tests.txt
-    #   packaging
-pyrsistent==0.17.3
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   jsonschema
+    #   build
 pytest==7.4.4
     # via -r requirements/tests.txt
 python-dateutil==2.8.2
@@ -242,6 +252,12 @@ redis==2.10.6
     #   -r requirements/tests.txt
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/requirements.txt
@@ -255,21 +271,26 @@ requests-file==1.5.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   tldextract
+rpds-py==0.16.2
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
@@ -278,7 +299,7 @@ six==1.15.0
     #   wsgiprox
 snowballstemmer==2.2.0
     # via pydocstyle
-soupsieve==2.2
+soupsieve==2.5
     # via
     #   -r requirements/tests.txt
     #   beautifulsoup4
@@ -287,28 +308,28 @@ surt==0.3.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   certauth
     #   pywb
     #   surt
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/tests.txt
     #   build
-    #   pep517
     #   pip-tools
     #   pylint
+    #   pyproject-hooks
     #   pytest
-tomlkit==0.11.0
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.9.0
     # via
     #   astroid
     #   pylint
-ua-parser==0.10.0
+ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -342,7 +363,7 @@ webencodings==0.5.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
@@ -355,7 +376,7 @@ werkzeug==2.1.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-wheel==0.38.1
+wheel==0.42.0
     # via
     #   -r requirements/tests.txt
     #   pip-tools
@@ -368,34 +389,33 @@ wsgiprox==1.5.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via
     #   -r requirements/tests.txt
     #   pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   gevent
-    #   jsonschema
     #   pip-tools
     #   zope-event
     #   zope-interface

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,76 +4,84 @@
 #
 #    pip-compile --allow-unsafe requirements/requirements.in
 #
-attrs==20.3.0
-    # via jsonschema
+attrs==23.2.0
+    # via
+    #   jsonschema
+    #   referencing
 brotlipy==0.7.0
     # via pywb
 certauth==1.3.0
     # via wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.in
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   pyopenssl
     #   python-jose
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via py3amf
 ecdsa==0.18.0
     # via python-jose
 fakeredis==0.16.0
     # via pywb
+filelock==3.13.1
+    # via tldextract
 gevent==21.12.0
     # via pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via gevent
 h-vialib==1.2.1
     # via -r requirements/requirements.in
-idna==2.10
+idna==3.6
     # via
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via h-vialib
 importlib-resources==6.1.1
     # via
     #   -r requirements/requirements.in
     #   checkmatelib
+    #   jsonschema
+    #   jsonschema-specifications
 jinja2==2.11.3
     # via pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+markupsafe==2.0.1
     # via
     #   jinja2
     #   pywb
-netaddr==0.8.0
+netaddr==0.10.1
     # via checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via -r requirements/requirements.in
-portalocker==2.0.0
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
+portalocker==2.8.2
     # via pywb
-py3amf==0.8.10
+py3amf==0.8.11
     # via pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via certauth
-pyrsistent==0.17.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via pywb
 python-jose[cryptography]==3.3.0
@@ -86,6 +94,10 @@ redis==2.10.6
     # via
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   checkmatelib
@@ -94,14 +106,17 @@ requests==2.31.0
     #   tldextract
 requests-file==1.5.1
     # via tldextract
+rpds-py==0.16.2
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via -r requirements/requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
@@ -110,12 +125,12 @@ six==1.15.0
     #   wsgiprox
 surt==0.3.1
     # via pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   certauth
     #   pywb
     #   surt
-ua-parser==0.10.0
+ua-parser==0.18.0
     # via pywb
 urllib3==1.26.18
     # via
@@ -129,7 +144,7 @@ webassets==2.0
     # via pywb
 webencodings==0.5.1
     # via pywb
-webob==1.8.6
+webob==1.8.7
     # via h-vialib
 werkzeug==2.1.2
     # via pywb
@@ -137,19 +152,18 @@ whitenoise==6.6.0
     # via -r requirements/requirements.in
 wsgiprox==1.5.2
     # via pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   gevent
-    #   jsonschema
     #   zope-event
     #   zope-interface

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,48 +4,49 @@
 #
 #    pip-compile --allow-unsafe requirements/tests.in
 #
-attrs==20.3.0
+attrs==23.2.0
     # via
     #   -r requirements/requirements.txt
     #   jsonschema
-beautifulsoup4==4.9.3
+    #   referencing
+beautifulsoup4==4.12.2
     # via webtest
 brotlipy==0.7.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-build==0.8.0
+build==1.0.3
     # via pip-tools
 certauth==1.3.0
     # via
     #   -r requirements/requirements.txt
     #   wsgiprox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.2
+cffi==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   brotlipy
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==3.3.2
     # via
     #   -r requirements/requirements.txt
     #   requests
 checkmatelib==1.0.15
     # via -r requirements/requirements.txt
-click==8.1.3
+click==8.1.7
     # via pip-tools
 coverage==7.4.0
     # via -r requirements/tests.in
-cryptography==41.0.6
+cryptography==41.0.7
     # via
     #   -r requirements/requirements.txt
     #   pyopenssl
     #   python-jose
-defusedxml==0.6.0
+defusedxml==0.7.1
     # via
     #   -r requirements/requirements.txt
     #   py3amf
@@ -53,17 +54,21 @@ ecdsa==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-exceptiongroup==1.0.0
+exceptiongroup==1.2.0
     # via pytest
 fakeredis==0.16.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
+filelock==3.13.1
+    # via
+    #   -r requirements/requirements.txt
+    #   tldextract
 gevent==21.12.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-greenlet==1.1.2
+greenlet==1.1.3.post0
     # via
     #   -r requirements/requirements.txt
     #   gevent
@@ -73,82 +78,87 @@ h-vialib==1.2.1
     # via -r requirements/requirements.txt
 httpretty==1.1.4
     # via -r requirements/tests.in
-idna==2.10
+idna==3.6
     # via
     #   -r requirements/requirements.txt
     #   requests
     #   tldextract
-importlib-metadata==6.0.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/requirements.txt
+    #   build
     #   h-vialib
     #   pip-sync-faster
 importlib-resources==6.1.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-iniconfig==1.1.1
+    #   jsonschema
+    #   jsonschema-specifications
+iniconfig==2.0.0
     # via pytest
 jinja2==2.11.3
     # via
     #   -r requirements/requirements.txt
     #   pywb
-jsonschema==3.2.0
+jsonschema==4.20.0
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-markupsafe==1.1.1
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+markupsafe==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   jinja2
     #   pywb
-netaddr==0.8.0
+netaddr==0.10.1
     # via
     #   -r requirements/requirements.txt
     #   checkmatelib
-newrelic==9.3.0
+newrelic==9.4.0
     # via -r requirements/requirements.txt
-packaging==20.9
+packaging==23.2
     # via
     #   build
     #   pytest
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/tests.in
 pip-tools==7.3.0
     # via
     #   -r requirements/tests.in
     #   pip-sync-faster
-pluggy==0.13.1
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+pluggy==1.3.0
     # via pytest
-portalocker==2.0.0
+portalocker==2.8.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-py3amf==0.8.10
+py3amf==0.8.11
     # via
     #   -r requirements/requirements.txt
     #   pywb
-pyasn1==0.4.8
+pyasn1==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   python-jose
     #   rsa
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/requirements.txt
     #   cffi
-pyopenssl==23.2.0
+pyopenssl==23.3.0
     # via
     #   -r requirements/requirements.txt
     #   certauth
-pyparsing==2.4.7
-    # via packaging
-pyrsistent==0.17.3
-    # via
-    #   -r requirements/requirements.txt
-    #   jsonschema
+pyproject-hooks==1.0.0
+    # via build
 pytest==7.4.4
     # via -r requirements/tests.in
 python-dateutil==2.8.2
@@ -171,6 +181,11 @@ redis==2.10.6
     #   -r requirements/requirements.txt
     #   fakeredis
     #   pywb
+referencing==0.32.1
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements/requirements.txt
@@ -182,42 +197,46 @@ requests-file==1.5.1
     # via
     #   -r requirements/requirements.txt
     #   tldextract
+rpds-py==0.16.2
+    # via
+    #   -r requirements/requirements.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   python-jose
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
     # via -r requirements/requirements.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/requirements.txt
     #   ecdsa
-    #   jsonschema
     #   python-dateutil
     #   pywb
     #   requests-file
     #   surt
     #   warcio
     #   wsgiprox
-soupsieve==2.2
+soupsieve==2.5
     # via beautifulsoup4
 surt==0.3.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-tldextract==2.2.3
+tldextract==5.1.1
     # via
     #   -r requirements/requirements.txt
     #   certauth
     #   pywb
     #   surt
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-ua-parser==0.10.0
+ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
@@ -242,7 +261,7 @@ webencodings==0.5.1
     # via
     #   -r requirements/requirements.txt
     #   pywb
-webob==1.8.6
+webob==1.8.7
     # via
     #   -r requirements/requirements.txt
     #   h-vialib
@@ -253,7 +272,7 @@ werkzeug==2.1.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
 whitenoise==6.6.0
     # via -r requirements/requirements.txt
@@ -261,28 +280,27 @@ wsgiprox==1.5.2
     # via
     #   -r requirements/requirements.txt
     #   pywb
-zipp==3.4.1
+zipp==3.17.0
     # via
     #   -r requirements/requirements.txt
     #   importlib-metadata
     #   importlib-resources
-zope-event==4.5.0
+zope-event==5.0
     # via
     #   -r requirements/requirements.txt
     #   gevent
-zope-interface==5.2.0
+zope-interface==6.1
     # via
     #   -r requirements/requirements.txt
     #   gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==68.2.2
+setuptools==69.0.3
     # via
     #   -r requirements/requirements.txt
     #   gevent
-    #   jsonschema
     #   pip-tools
     #   zope-event
     #   zope-interface


### PR DESCRIPTION
This is the result of running:

make requirements --always-make args='--upgrade'

Non top level dependencies can become outdated as dependabot doesn't send PR for those.

On top of that upgrading single packages with all the existing constraints might make impassible to satisfy all constraints.

This approach makes sure we are up to date with all our dependencies as specified on the .in files but without considering any constraints in the .txt files