### PR TITLE
Support disabling proxying of iframes on a per-request basis via `via.proxy_frames` query param

### DIFF
--- a/tests/unit/viahtml/context_test.py
+++ b/tests/unit/viahtml/context_test.py
@@ -188,6 +188,18 @@ class TestContext:
 
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("via.proxy_frames=0", {"proxy_frames": "0"}),
+            ("via.foo.bar=baz", {"foo": {"bar": "baz"}}),
+        ],
+    )
+    def test_via_config(self, context, environ, query, expected):
+        environ["QUERY_STRING"] = query
+        result = context.via_config
+        assert result == expected
+
     @pytest.fixture
     def environ(self):
         return {

--- a/tests/unit/viahtml/hooks/hooks_test.py
+++ b/tests/unit/viahtml/hooks/hooks_test.py
@@ -190,6 +190,22 @@ class TestHooks:
             "url", proxy=False, rewrite_fragments=False
         )
 
+    @pytest.mark.parametrize(
+        "via_config,expected_stop",
+        [
+            ({}, False),
+            ({"proxy_frames": "0"}, True),
+            ({"proxy_frames": "1"}, False),
+            ({"proxy_frames": "meh"}, True),
+        ],
+    )
+    def test_modify_tag_attrs_disables_iframe_proxying(
+        self, hooks, via_config, expected_stop
+    ):
+        hooks.context.via_config = via_config
+        _, stop = hooks.modify_tag_attrs("iframe", [])
+        assert stop == expected_stop
+
     @pytest.fixture
     def wb_response(self):
         return WbResponse(status_headers=StatusAndHeaders("200 OK", headers=[]))
@@ -201,6 +217,7 @@ class TestHooks:
         context.make_absolute.side_effect = (
             lambda url, proxy=True, rewrite_fragments=True: url
         )
+        context.via_config = {}
         return context
 
     @pytest.fixture

--- a/viahtml/context.py
+++ b/viahtml/context.py
@@ -91,6 +91,13 @@ class Context:
 
         return url if url else None
 
+    @property
+    @lru_cache(1)
+    def via_config(self):
+        """Return the parsed configuration from `via.*` query params."""
+        via_config, _ = Configuration.extract_from_wsgi_environment(self.http_environ)
+        return via_config
+
     def make_response(self, http_status=HTTPStatus.OK, headers=None, lines=None):
         """Create a WSGI response.
 

--- a/viahtml/patch.py
+++ b/viahtml/patch.py
@@ -1,24 +1,28 @@
 """Tools to apply the hooks to a running `pywb` app."""
 
+from typing import Optional
+
 from pywb.apps.rewriterapp import RewriterApp
 from pywb.rewrite.default_rewriter import DefaultRewriter
 from pywb.rewrite.html_rewriter import HTMLRewriter
 from pywb.rewrite.url_rewriter import UrlRewriter
 
+from viahtml.hooks import Hooks
 
-def apply_post_app_hooks(rewriter_app, hooks):
+
+def apply_post_app_hooks(rewriter_app, hooks: Hooks):
     """Apply hooks after the app has been instantiated."""
     _PatchedRewriterApp.patch(rewriter_app, hooks)
 
 
-def apply_pre_app_hooks(hooks):
+def apply_pre_app_hooks(hooks: Hooks):
     """Apply hooks before the app has been instantiated."""
 
     _patch_url_rewriter(hooks)
     _PatchedHTMLRewriter.patch(hooks)
 
 
-def _patch_url_rewriter(hooks):
+def _patch_url_rewriter(hooks: Hooks):
     # Modify the list of prefixes that prevent a URL from being rewritten
     prefixes = list(UrlRewriter.NO_REWRITE_URI_PREFIX)
     prefixes.extend(hooks.ignore_prefixes)
@@ -26,10 +30,10 @@ def _patch_url_rewriter(hooks):
 
 
 class _PatchedHTMLRewriter(HTMLRewriter):  # pylint: disable=abstract-method
-    hooks = None
+    hooks: Optional[Hooks] = None
 
     @classmethod
-    def patch(cls, hooks):
+    def patch(cls, hooks: Hooks):
         """Patch the parent object."""
 
         cls.hooks = hooks
@@ -74,10 +78,10 @@ class _PatchedHTMLRewriter(HTMLRewriter):  # pylint: disable=abstract-method
 
 
 class _PatchedRewriterApp(RewriterApp):
-    hooks = None
+    hooks: Optional[Hooks] = None
 
     @classmethod
-    def patch(cls, rewriter, hooks):
+    def patch(cls, rewriter, hooks: Hooks):
         """Patch the rewriter object."""
 
         # Change the class of the rewriter to be this class, forcibly casting


### PR DESCRIPTION
This PR adds support for disabling proxying of iframes on a per-request basis by adding a `via.proxy_iframes=0` query param to the Via URL.

The downside of not proxying iframes is that the non-proxied frame will become cross-origin with its parent, which will break any JS code that assumes it can reach from the parent into the frame, or vice-versa.

Ideally we would avoid proxying frames by default in Via, since it would save resources on our side (less content to proxy), and make any content in the iframes load faster. However because there is some compatibility risk (ie. breaking sites that used to work), we'll need to roll this change out incrementally. The initial use case is https://github.com/hypothesis/lms/pull/6045.

Part of https://github.com/hypothesis/support/issues/98.