### PR TITLE
Fix Docker build after switch to Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/hypothesis hy
 WORKDIR /var/lib/hypothesis
 
 # Ensure nginx state and log directories writeable by unprivileged user.
-RUN chown -R hypothesis:hypothesis /etc/nginx/conf.d /var/log/nginx /var/lib/nginx
+RUN chown -R hypothesis:hypothesis /var/log/nginx /var/lib/nginx
 
 # Copy minimal data to allow installation of python dependencies.
 COPY ./requirements/requirements.txt ./


### PR DESCRIPTION
The fix here matches the Dockerfile in h.