### PR TITLE
Revise worker and memory usage limits for uWSGI workers

### DIFF
--- a/conf/production.ini
+++ b/conf/production.ini
@@ -1,1 +1,1 @@
-uwsgi/t3_small.ini
+uwsgi/t3_medium.ini

--- a/conf/uwsgi/t3_medium.ini
+++ b/conf/uwsgi/t3_medium.ini
@@ -34,7 +34,7 @@ worker-reload-mercy = 60             # How long to wait before forcefully killin
 # Worker cheaping
 
 cheaper-algo = busyness
-processes = 32                       # Maximum number of workers allowed
+processes = 64                       # Maximum number of workers allowed
 cheaper = 4                          # Minimum number of workers allowed
 cheaper-initial = 16                 # Workers created at startup
 cheaper-overload = 1                 # Length of a cycle in seconds
@@ -45,11 +45,6 @@ cheaper-busyness-min = 20            # Below this threshold, kill workers (if st
 cheaper-busyness-max = 70            # Above this threshold, spawn new workers
 cheaper-busyness-backlog-alert = 8   # Spawn emergency workers if more than this many requests are waiting in the queue
 cheaper-busyness-backlog-step = 2    # How many emergency workers to create if there are too many requests in the queue
-
-# These values need to be trimmed down while running inside Via, but can flex
-# back up depending on the machine they are deployed on
-cheaper-rss-limit-soft = 1342177280  # Don't spawn new workers if total RSS over 1280Mb
-cheaper-rss-limit-hard = 1610612736  # Kill a worker if total RSS over 1536MB (t3-small has 2G)
 
 # Better names in logs
 


### PR DESCRIPTION
In production workers have a typical RSS of ~90MB, but of that only 45-50MB is private to the process. With the previous RSS limits, production was effectively capped at 17 workers (1536 / 90 ~= 17). Additionally the configuration assumed 2GB memory per host, but the configuration was subsequently changed to use t3.medium with 4GB.

This commit raises the cap on the number of workers and removes the fixed memory limits, which were outdated. This should allow the service to scale up workers better to meet bursts of demand.

See https://github.com/hypothesis/viahtml/issues/696