### PR TITLE
Add a temporary hack to upgrade gevent and greenlet in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN apk add --no-cache --virtual build-deps \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps
 
+# Temporarily install the latest gevent and greenlet releases. This version is
+# incompatible with pywb's stated requirements, but it nevertheless runs.
+#
+# The newer gevent release includes bugfixes for Python >= 3.11.8.
+RUN pip install --no-cache-dir gevent==24.2.1 greenlet==3.1.0
+
 COPY ./conf/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./conf/nginx/viahtml /etc/nginx/viahtml
 COPY . .


### PR DESCRIPTION
gevent is used by both uWSGI and pywb. pywb pins it to v22.10.2. However there have been fixes for the version of Python we are using in v24.2.1. In order to test whether the older version of gevent is responsible for hangs we are seeing in production, update gevent in the Docker container.

Testing:

- Build docker container locally with `make docker`
- Run viahtml container with `make run-docker`
- Run the local _via_ service using `make dev`, and check that you can browse to http://localhost:9083/https://example.org/

See also:
- [gevent changelog](https://www.gevent.org/changelog.html)
- [Slack thread](https://hypothes-is.slack.com/archives/C4K6M7P5E/p1726476148088089?thread_ts=1726470138.505809&cid=C4K6M7P5E)