### PR TITLE
Support dumping gevent stacks from uWSGI workers

### DIFF
--- a/viahtml/wsgi.py
+++ b/viahtml/wsgi.py
@@ -1,10 +1,21 @@
 """The application providing a WSGI entry-point."""
 
 import os
+import signal
 
 # Our job here is to leave this `application` attribute laying around as
 # it's what uWSGI expects to find.
 from viahtml.app import Application
+
+
+def _dump_stacks(_signal, frame):  # pylint:disable=unused-argument, # pragma: no cover
+    # Print both Python thread and gevent "greenlet" stats and backtraces.
+    #
+    # See https://www.gevent.org/monitoring.html#visibility
+    import gevent  # pylint:disable=import-outside-toplevel
+
+    gevent.util.print_run_info()
+
 
 application = Application()
 
@@ -17,3 +28,11 @@ if os.environ.get("SENTRY_DSN"):  # pragma: no cover
     # pylint: disable=redefined-variable-type
     sentry_sdk.init(dsn=os.environ["SENTRY_DSN"])
     application = SentryWsgiMiddleware(application)
+
+# Add a way to dump stacks so we can see what a uWSGI worker is doing if it
+# hangs.
+#
+# We use `SIGCONT` for this because this handler isn't used for anything
+# important, and uWSGI defines its own `SIGUSR1` and `SIGUSR2` handlers after
+# this code runs.
+signal.signal(signal.SIGCONT, _dump_stacks)


### PR DESCRIPTION
To help debug cases where a worker process "hangs", add a SIGCONT signal handler which dumps both the native and greenlet threads.

**Testing:**

1. Run `make dev`
2. Find pid of a uwsgi worker by running `ps aux | grep uwsgi`
3. Send signal to uwsgi worker using `kill -s SIGCONT $PID`

This will cause native and greenlet stack traces to be dumped to the worker's stderr.