### PR TITLE
Pin urllib3 to v1.26.15

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -234,7 +234,7 @@ ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-urllib3==1.26.19
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   requests

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -207,7 +207,7 @@ ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-urllib3==1.26.19
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   requests

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -293,7 +293,7 @@ ua-parser==0.18.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pywb
-urllib3==1.26.19
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,3 +6,10 @@ pywb
 sentry-sdk
 uwsgi
 whitenoise
+
+# Pin urllib3 to a version <1.26.16 to investigate if it resolves issues with
+# gevent.
+#
+# See https://github.com/gevent/gevent/issues/1957 and
+# https://github.com/urllib3/urllib3/issues/3289.
+urllib3==1.26.15

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -120,8 +120,9 @@ tldextract==5.1.1
     #   surt
 ua-parser==0.18.0
     # via pywb
-urllib3==1.26.19
+urllib3==1.26.15
     # via
+    #   -r requirements/requirements.in
     #   requests
     #   sentry-sdk
 uwsgi==2.0.26

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -211,7 +211,7 @@ ua-parser==0.18.0
     # via
     #   -r requirements/requirements.txt
     #   pywb
-urllib3==1.26.19
+urllib3==1.26.15
     # via
     #   -r requirements/requirements.txt
     #   requests


### PR DESCRIPTION
urllib3 v1.26.16 was reported by some GitHub users as encountering deadlocks in gevent. Pin to an earlier version to test whether this makes a difference in our case.

See comments in https://github.com/gevent/gevent/issues/1957 and https://github.com/urllib3/urllib3/issues/3289.
Slack investigation: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1726591090893969?thread_ts=1726470138.505809&cid=C4K6M7P5E
urllib3 changelog: https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#12616-2023-05-23